### PR TITLE
Feature/dolfinx adapters

### DIFF
--- a/.github/actions/install-adapted-packages/action.yml
+++ b/.github/actions/install-adapted-packages/action.yml
@@ -43,3 +43,28 @@ runs:
           sudo cmake --install build
         popd && rm -rf cgal
       shell: bash
+    - name: install-dolfinx
+      run: |
+        sudo apt-get install libblas-dev \
+                             liblapack-dev \
+                             pybind11-dev \
+                             libpugixml-dev \
+                             libboost-timer-dev \
+                             libboost-filesystem-dev \
+                             petsc-dev
+        pip install fenics-ffcx pybind11
+
+        git clone --depth=1 --branch=v0.6.0 https://github.com/FEniCS/basix.git
+        pushd basix
+            cmake -DCMAKE_INSTALL_PREFIX=/gridformat-manually-installed-deps/ -B build
+            cmake --build build && sudo cmake --install build
+        popd
+        rm -rf basix
+
+        git clone --depth=1 --branch=v0.6.0 https://github.com/FEniCS/dolfinx.git
+        pushd dolfinx/cpp
+            cmake -DCMAKE_INSTALL_PREFIX=/gridformat-manually-installed-deps/ -B build
+            cmake --build build && sudo cmake --install build
+        popd
+        rm -rf dolfinx
+      shell: bash

--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ and [the guide on grid traits specialization](https://github.com/dglaeser/gridfo
 `GridFormat` comes with predefined traits for
 [dune grid views](https://www.dune-project.org/doxygen/2.8.0/classDune_1_1GridView.html) (tested dune version: 2.9),
 [deal.ii triangulations](https://www.dealii.org/current/doxygen/deal.II/classTriangulation.html) (tested deal.ii version: 9.4.0).
-and [cgal](https://www.cgal.org/) triangulations in
+, [cgal](https://www.cgal.org/) triangulations in
 [2d](https://doc.cgal.org/latest/Triangulation_2/index.html) and
-[3d](https://doc.cgal.org/latest/Triangulation_3/index.html) (tested cgal version: 5.5.2).
+[3d](https://doc.cgal.org/latest/Triangulation_3/index.html) (tested cgal version: 5.5.2),
+and [dolfinx](https://github.com/FEniCS/dolfinx) meshes and function spaces (tested dolfinx version: 0.6.0).
 Users of these frameworks can include these predefined traits and use `GridFormat` directly
 (see the [examples](https://github.com/dglaeser/gridformat/tree/main/examples)).
 

--- a/gridformat/grid/adapters/dolfinx.hpp
+++ b/gridformat/grid/adapters/dolfinx.hpp
@@ -266,10 +266,8 @@ class Mesh {
 
     template<int rank = 0, int dim = 3, Concepts::Scalar T>
     auto _evaluate(const dolfinx::fem::Function<T>& f, const std::integral auto i) const {
-        const auto f_rank = f.function_space()->element()->value_shape().size();
         const auto f_components = f.function_space()->element()->block_size();
-
-        assert(f_rank == rank);
+        assert(f.function_space()->element()->value_shape().size() == rank);
         assert(f.x()->array().size() >= static_cast<std::size_t>(i*f_components + f_components));
 
         if constexpr (rank == 0)

--- a/gridformat/grid/adapters/dolfinx.hpp
+++ b/gridformat/grid/adapters/dolfinx.hpp
@@ -1,0 +1,356 @@
+// SPDX-FileCopyrightText: 2022 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*!
+ * \file
+ * \ingroup Adapters
+ * \brief Traits specializations for <a href="https://docs.fenicsproject.org/dolfinx/v0.6.0/cpp/">dolfinx meshes</a>
+ */
+#ifndef GRIDFORMAT_ADAPTERS_DOLFINX_HPP_
+#define GRIDFORMAT_ADAPTERS_DOLFINX_HPP_
+
+#include <array>
+#include <ranges>
+#include <cstdint>
+#include <utility>
+#include <memory>
+#include <algorithm>
+
+#include <dolfinx/io/vtk_utils.h>
+
+#include <gridformat/common/ranges.hpp>
+#include <gridformat/common/exceptions.hpp>
+#include <gridformat/grid/cell_type.hpp>
+#include <gridformat/grid/traits.hpp>
+
+// Important: the dolfinx headers must be included before this one!
+
+namespace GridFormat {
+
+namespace DolfinX {
+
+struct Cell { std::int32_t index; };
+struct Point { std::int32_t index; };
+
+#ifndef DOXYGEN
+namespace Detail {
+    CellType cell_type(dolfinx::mesh::CellType ct) {
+        // since dolfinx supports higher-order cells, let's simply return the lagrange variants always
+        switch (ct) {
+            case dolfinx::mesh::CellType::point: return GridFormat::CellType::vertex;
+            case dolfinx::mesh::CellType::interval: return GridFormat::CellType::lagrange_segment;
+            case dolfinx::mesh::CellType::triangle: return GridFormat::CellType::lagrange_triangle;
+            case dolfinx::mesh::CellType::quadrilateral: return GridFormat::CellType::lagrange_quadrilateral;
+            case dolfinx::mesh::CellType::tetrahedron: return GridFormat::CellType::lagrange_tetrahedron;
+            case dolfinx::mesh::CellType::pyramid: break;
+            case dolfinx::mesh::CellType::prism: break;
+            case dolfinx::mesh::CellType::hexahedron: return GridFormat::CellType::lagrange_hexahedron;
+        }
+        throw NotImplemented("Support for dolfinx cell type '" + dolfinx::mesh::to_string(ct) + "'");
+    }
+}  // namespace Detail
+#endif  // DOXYGEN
+
+}  // namespace DolfinX
+
+namespace Traits {
+
+template<>
+struct Cells<dolfinx::mesh::Mesh> {
+    static std::ranges::range auto get(const dolfinx::mesh::Mesh& mesh) {
+        auto map = mesh.topology().index_map(mesh.topology().dim());
+        if (!map) throw GridFormat::ValueError("Cell index map not available");
+        return std::views::iota(0, map->size_local()) | std::views::transform([] (std::int32_t i) {
+            return DolfinX::Cell{i};
+        });
+    }
+};
+
+template<>
+struct CellType<dolfinx::mesh::Mesh, DolfinX::Cell> {
+    static GridFormat::CellType get(const dolfinx::mesh::Mesh& mesh, const DolfinX::Cell&) {
+        return DolfinX::Detail::cell_type(mesh.topology().cell_type());
+    }
+};
+
+template<>
+struct CellPoints<dolfinx::mesh::Mesh, DolfinX::Cell> {
+    static std::ranges::range auto get(const dolfinx::mesh::Mesh& mesh, const DolfinX::Cell& cell) {
+        std::span links = mesh.geometry().dofmap().links(cell.index);
+        auto permutation = dolfinx::io::cells::transpose(
+            dolfinx::io::cells::perm_vtk(mesh.topology().cell_type(), links.size())
+        );
+        return std::views::iota(std::size_t{0}, links.size())
+            | std::views::transform([perm = std::move(permutation), links=links] (std::size_t i) {
+                return DolfinX::Point{links[perm[i]]};
+            }
+        );
+    }
+};
+
+template<>
+struct Points<dolfinx::mesh::Mesh> {
+    static std::ranges::range auto get(const dolfinx::mesh::Mesh& mesh) {
+        const auto num_points = mesh.geometry().x().size()/3;
+        return std::views::iota(std::size_t{0}, num_points) | std::views::transform([] (std::size_t i) {
+            return DolfinX::Point{static_cast<std::int32_t>(i)};
+        });
+    }
+};
+
+template<>
+struct PointCoordinates<dolfinx::mesh::Mesh, DolfinX::Point> {
+    static std::ranges::range auto get(const dolfinx::mesh::Mesh& mesh, const DolfinX::Point& point) {
+        return std::array{
+            mesh.geometry().x()[point.index*3],
+            mesh.geometry().x()[point.index*3 + 1],
+            mesh.geometry().x()[point.index*3 + 2]
+        };
+    }
+};
+
+template<>
+struct PointId<dolfinx::mesh::Mesh, DolfinX::Point> {
+    static std::integral auto get(const dolfinx::mesh::Mesh&, const DolfinX::Point& point) {
+        return point.index;
+    }
+};
+
+template<>
+struct NumberOfPoints<dolfinx::mesh::Mesh> {
+    static std::integral auto get(const dolfinx::mesh::Mesh& mesh) {
+        return mesh.geometry().x().size()/3;
+    }
+};
+
+template<>
+struct NumberOfCells<dolfinx::mesh::Mesh> {
+    static std::integral auto get(const dolfinx::mesh::Mesh& mesh) {
+        auto map = mesh.topology().index_map(mesh.topology().dim());
+        if (!map) throw GridFormat::ValueError("Cell index map not available");
+        return map->size_local();
+    }
+};
+
+template<>
+struct NumberOfCellPoints<dolfinx::mesh::Mesh, DolfinX::Cell> {
+    static std::integral auto get(const dolfinx::mesh::Mesh& mesh, const DolfinX::Cell& cell) {
+        return mesh.geometry().dofmap().links(cell.index).size();
+    }
+};
+
+}  // namespace Traits
+
+namespace DolfinX {
+
+class Mesh {
+ public:
+    Mesh() = default;
+    Mesh(const dolfinx::fem::FunctionSpace& space) {
+        if (!space.mesh() || !space.element())
+            throw ValueError("Cannot construct mesh from space without mesh or element");
+
+        _cell_type = space.mesh()->topology().cell_type();
+        _mesh = space.mesh();
+        _element = space.element();
+
+        auto [x, xshape, xids, _ghosts, cells, cells_shape] = dolfinx::io::vtk_mesh_from_space(space);
+        _node_coords = std::move(x);
+        _node_coords_shape = std::move(xshape);
+        _node_ids = std::move(xids);
+        _cells = std::move(cells);
+        _cells_shape = std::move(cells_shape);
+        _set = true;
+    }
+
+    void update(const dolfinx::fem::FunctionSpace& space) {
+        *this = Mesh{space};
+    }
+
+    void clear() {
+        _mesh = nullptr;
+        _element = nullptr;
+        _node_coords.clear();
+        _node_ids.clear();
+        _cells.clear();
+        _set = false;
+    }
+
+    static Mesh from(const dolfinx::fem::FunctionSpace& space) {
+        return {space};
+    }
+
+    std::integral auto number_of_points() const { return _node_coords_shape[0]; }
+    std::integral auto number_of_cells() const { return _cells_shape[0]; }
+    std::integral auto number_of_cell_points() const { return _cells_shape[1]; }
+
+    std::int64_t id(const Point& p) const {
+        return _node_ids[p.index];
+    }
+
+    auto position(const Point& p) const {
+        assert(_node_coords_shape[1] == 3);
+        return std::array{
+            _node_coords[p.index*3],
+            _node_coords[p.index*3 + 1],
+            _node_coords[p.index*3 + 2]
+        };
+    }
+
+    std::ranges::range auto points() const {
+        _check_built();
+        return std::views::iota(std::size_t{0}, _node_coords_shape[0])
+            | std::views::transform([] (std::size_t i) {
+                return Point{static_cast<std::int32_t>(i)};
+            });
+    }
+
+    std::ranges::range auto points(const Cell& cell) const {
+        return std::views::iota(std::size_t{0}, _cells_shape[1])
+            | std::views::transform([&, i=cell.index, ncorners=_cells_shape[1]] (std::size_t local_point_index) {
+                return Point{static_cast<std::int32_t>(_cells[i*ncorners + local_point_index])};
+            });
+    }
+
+    std::ranges::range auto cells() const {
+        _check_built();
+        return std::views::iota(std::size_t{0}, _cells_shape[0])
+            | std::views::transform([] (std::size_t i) {
+                return Cell{static_cast<std::int32_t>(i)};
+            });
+    }
+
+    template<int rank = 0, int dim = 3, Concepts::Scalar T>
+    auto evaluate(const dolfinx::fem::Function<T>& f, const Cell& c) const {
+        assert(_is_cellwise_constant(*f.function_space()));
+        return _evaluate<rank, dim>(f, c.index);
+    }
+
+    template<int rank = 0, int dim = 3, Concepts::Scalar T>
+    auto evaluate(const dolfinx::fem::Function<T>& f, const Point& p) const {
+        assert(_element);
+        assert(!_is_cellwise_constant(*f.function_space()));
+        assert(*f.function_space()->element() == *_element);
+        return _evaluate<rank, dim>(f, p.index);
+    }
+
+    auto cell_type() const {
+        return _cell_type;
+    }
+
+ private:
+    void _check_built() const {
+        if (!_set)
+            throw InvalidState("Mesh has not been built");
+    }
+
+    bool _is_cellwise_constant(const dolfinx::fem::FunctionSpace& space) const {
+        assert(space.element());
+        return space.dofmap()->element_dof_layout().num_dofs() == 1;
+    }
+
+    template<int rank = 0, int dim = 3, Concepts::Scalar T>
+    auto _evaluate(const dolfinx::fem::Function<T>& f, const std::integral auto i) const {
+        assert(f.function_space()->mesh());
+        assert(f.function_space()->mesh() == _mesh);
+        const auto f_rank = f.function_space()->element()->value_shape().size();
+        const auto f_components = f.function_space()->element()->block_size();
+
+        assert(f_rank == rank);
+        assert(f.x()->array().size() >= static_cast<std::size_t>(i*f_components + f_components));
+        if constexpr (rank == 0)
+            return f.x()->array()[i*f_components];
+        if constexpr (rank == 1) {
+            auto result = Ranges::filled_array<dim>(T{0});
+            std::copy_n(
+                f.x()->array().data() + i*f_components,
+                std::min(dim, f_components),
+                result.begin()
+            );
+            return result;
+        }
+        throw NotImplemented("Tensor evaluation");
+    }
+
+    dolfinx::mesh::CellType _cell_type;
+    std::shared_ptr<const dolfinx::mesh::Mesh> _mesh{nullptr};
+    std::shared_ptr<const dolfinx::fem::FiniteElement> _element{nullptr};
+
+    std::vector<double> _node_coords;
+    std::array<std::size_t, 2> _node_coords_shape;
+    std::vector<std::int64_t> _node_ids;
+    std::vector<std::int64_t> _cells;
+    std::array<std::size_t, 2> _cells_shape;
+    bool _set = false;
+};
+
+}  // namespace DolfinX
+
+namespace Traits {
+
+template<>
+struct Cells<DolfinX::Mesh> {
+    static std::ranges::range auto get(const DolfinX::Mesh& mesh) {
+        return mesh.cells();
+    }
+};
+
+template<>
+struct CellType<DolfinX::Mesh, DolfinX::Cell> {
+    static GridFormat::CellType get(const DolfinX::Mesh& mesh, const DolfinX::Cell&) {
+        return DolfinX::Detail::cell_type(mesh.cell_type());
+    }
+};
+
+template<>
+struct CellPoints<DolfinX::Mesh, DolfinX::Cell> {
+    static std::ranges::range auto get(const DolfinX::Mesh& mesh, const DolfinX::Cell& cell) {
+        return mesh.points(cell);
+    }
+};
+
+template<>
+struct Points<DolfinX::Mesh> {
+    static std::ranges::range auto get(const DolfinX::Mesh& mesh) {
+        return mesh.points();
+    }
+};
+
+template<>
+struct PointCoordinates<DolfinX::Mesh, DolfinX::Point> {
+    static std::ranges::range auto get(const DolfinX::Mesh& mesh, const DolfinX::Point& point) {
+        return mesh.position(point);
+    }
+};
+
+template<>
+struct PointId<DolfinX::Mesh, DolfinX::Point> {
+    static std::integral auto get(const DolfinX::Mesh& mesh, const DolfinX::Point& point) {
+        return mesh.id(point);
+    }
+};
+
+template<>
+struct NumberOfPoints<DolfinX::Mesh> {
+    static std::integral auto get(const DolfinX::Mesh& mesh) {
+        return mesh.number_of_points();
+    }
+};
+
+template<>
+struct NumberOfCells<DolfinX::Mesh> {
+    static std::integral auto get(const DolfinX::Mesh& mesh) {
+        return mesh.number_of_cells();
+    }
+};
+
+template<>
+struct NumberOfCellPoints<DolfinX::Mesh, DolfinX::Cell> {
+    static std::integral auto get(const DolfinX::Mesh& mesh, const DolfinX::Cell&) {
+        return mesh.number_of_cell_points();
+    }
+};
+
+}  // namespace Traits
+}  // namespace GridFormat
+
+#endif  // GRIDFORMAT_ADAPTERS_DUNE_HPP_

--- a/gridformat/grid/cell_type.hpp
+++ b/gridformat/grid/cell_type.hpp
@@ -19,14 +19,22 @@ namespace GridFormat {
  */
 enum class CellType {
     vertex,
+
     segment,
     triangle,
     pixel,
     quadrilateral,
     polygon,
+
     tetrahedron,
     hexahedron,
-    voxel
+    voxel,
+
+    lagrange_segment,
+    lagrange_triangle,
+    lagrange_quadrilateral,
+    lagrange_tetrahedron,
+    lagrange_hexahedron
 };
 
 }  // namespace GridFormat

--- a/gridformat/grid/cell_type.hpp
+++ b/gridformat/grid/cell_type.hpp
@@ -9,7 +9,6 @@
 #define GRIDFORMAT_GRID_CELL_TYPE_HPP_
 
 #include <gridformat/common/exceptions.hpp>
-#include <gridformat/common/logging.hpp>
 
 namespace GridFormat {
 

--- a/gridformat/grid/grid.hpp
+++ b/gridformat/grid/grid.hpp
@@ -161,6 +161,7 @@ std::unordered_map<std::size_t, std::size_t> make_point_id_map(const Grid& grid)
     std::size_t i = 0;
     std::unordered_map<std::size_t, std::size_t> point_id_to_running_idx;
     for (const auto& p : points(grid)) {
+        assert(id(grid, p) >= 0);
         point_id_to_running_idx[id(grid, p)] = i++;
     }
     return point_id_to_running_idx;

--- a/gridformat/vtk/common.hpp
+++ b/gridformat/vtk/common.hpp
@@ -79,6 +79,11 @@ inline constexpr std::uint8_t cell_type_number(CellType t) {
         case (CellType::tetrahedron): return 10;
         case (CellType::hexahedron): return 12;
         case (CellType::voxel): return 11;
+        case (CellType::lagrange_segment): return 68;
+        case (CellType::lagrange_triangle): return 69;
+        case (CellType::lagrange_quadrilateral): return 70;
+        case (CellType::lagrange_tetrahedron): return 71;
+        case (CellType::lagrange_hexahedron): return 72;
     }
 
     throw NotImplemented("VTK cell type number for the given cell type");

--- a/gridformat/vtk/xml.hpp
+++ b/gridformat/vtk/xml.hpp
@@ -228,7 +228,7 @@ class XMLWriterBase
             return std::visit([&] (const auto& header_precision) {
                 XMLElement xml("VTKFile");
                 xml.set_attribute("type", vtk_grid_type);
-                xml.set_attribute("version", "2.0");
+                xml.set_attribute("version", "2.2");
                 xml.set_attribute("byte_order", attribute_name(std::endian::native));
                 xml.set_attribute("header_type", attribute_name(DynamicPrecision{header_precision}));
                 if constexpr (!is_none<std::decay_t<decltype(compressor)>>)

--- a/test/adapters/CMakeLists.txt
+++ b/test/adapters/CMakeLists.txt
@@ -19,13 +19,13 @@ gridformat_add_parallel_regression_test_if(DOLFINX_FOUND
     test_dolfinx
     test_dolfinx.cpp
     2
-    "dolfinx_*"
+    "dolfinx_*nranks_2*"
 )
 gridformat_add_parallel_regression_test_if(DOLFINX_FOUND
     test_dolfinx_sequential
     test_dolfinx.cpp
     1
-    "dolfinx_*sequential*"
+    "dolfinx_*nranks_1*"
 )
 if (DOLFINX_FOUND)
     message(STATUS "Testing dolfinx traits with version ${DOLFINX_VERSION}")

--- a/test/adapters/CMakeLists.txt
+++ b/test/adapters/CMakeLists.txt
@@ -14,6 +14,25 @@ if (CGAL_FOUND)
     target_compile_options(test_cgal PRIVATE -frounding-math)
 endif ()
 
+find_package(DOLFINX)
+gridformat_add_parallel_regression_test_if(DOLFINX_FOUND
+    test_dolfinx
+    test_dolfinx.cpp
+    2
+    "dolfinx_*"
+)
+gridformat_add_parallel_regression_test_if(DOLFINX_FOUND
+    test_dolfinx_sequential
+    test_dolfinx.cpp
+    1
+    "dolfinx_*sequential*"
+)
+if (DOLFINX_FOUND)
+    message(STATUS "Testing dolfinx traits with version ${DOLFINX_VERSION}")
+    target_link_libraries(test_dolfinx dolfinx)
+    target_link_libraries(test_dolfinx_sequential dolfinx)
+endif ()
+
 find_package(deal.II)
 if (deal.II_FOUND)
     message(STATUS "Testing deal.ii traits with deal.ii version ${deal.II_VERSION}")

--- a/test/adapters/test_cgal.cpp
+++ b/test/adapters/test_cgal.cpp
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include <vector>
 #include <utility>
 
 #pragma GCC diagnostic push
@@ -170,6 +169,8 @@ int main() {
     write(CGAL::Triangulation_2<ExactKernel, TDS2D<ExactKernel>>{}, "exact");
     write(CGAL::Delaunay_triangulation_2<Kernel, TDS2D<Kernel>>{}, "delaunay");
     write(CGAL::Delaunay_triangulation_2<ExactKernel, TDS2D<ExactKernel>>{}, "delaunay_exact");
+
+    write<GridFormat::VTPWriter>(CGAL::Delaunay_triangulation_2<ExactKernel, TDS2D<ExactKernel>>{}, "delaunay_exact_as_poly");
 
     write(RegularTriangulation2D<Kernel>{}, "regular");
     write(RegularTriangulation2D<ExactKernel>{}, "regular_exact");

--- a/test/adapters/test_dolfinx.cpp
+++ b/test/adapters/test_dolfinx.cpp
@@ -1,0 +1,280 @@
+// SPDX-FileCopyrightText: 2022 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <vector>
+#include <utility>
+#include <optional>
+#include <iterator>
+
+#include <dolfinx.h>
+
+#include <gridformat/grid/adapters/dolfinx.hpp>
+#include <gridformat/parallel/communication.hpp>
+#include <gridformat/grid/grid.hpp>
+
+#include <gridformat/vtk/vtu_writer.hpp>
+#include <gridformat/vtk/pvtu_writer.hpp>
+
+#include "../make_test_data.hpp"
+
+
+template<int dim>
+auto higher_order_mesh([[maybe_unused]] std::optional<dolfinx::mesh::CellType> ct = {}) {
+    if constexpr (dim == 1) {
+        return dolfinx::mesh::create_mesh(
+            MPI_COMM_WORLD,
+            dolfinx::graph::AdjacencyList<std::int64_t>{
+                std::vector<std::vector<std::size_t>>{{0, 1, 2}}
+            },
+            dolfinx::fem::CoordinateElement(dolfinx::mesh::CellType::interval, 2),
+            std::vector{
+                0., 0., 0.,
+                0.5, 0., 0.,
+                1., 0., 0.
+            },
+            {3, 3},
+            dolfinx::mesh::GhostMode::none
+        );
+    } else if constexpr (dim == 2) {
+        if (ct.value() == dolfinx::mesh::CellType::triangle)
+            return dolfinx::mesh::create_mesh(
+                MPI_COMM_WORLD,
+                dolfinx::graph::AdjacencyList<std::int64_t>{
+                    std::vector<std::vector<std::size_t>>{{0, 1, 2, 3, 4, 5}}
+                },
+                dolfinx::fem::CoordinateElement(
+                    dolfinx::mesh::CellType::triangle,
+                    /*order*/2,
+                    basix::element::lagrange_variant::equispaced
+                ),
+                std::vector{
+                    0., 0., 0.,
+                    1., 0., 0.,
+                    0., 1., 0.,
+                    0.5, 0.5, 0.,
+                    0., 0.5, 0.,
+                    0.5, 0., 0.
+                },
+                {6, 3},
+                dolfinx::mesh::GhostMode::none
+            );
+        else  // quadrilateral
+            return dolfinx::mesh::create_mesh(
+                MPI_COMM_WORLD,
+                dolfinx::graph::AdjacencyList<std::int64_t>{
+                    std::vector<std::vector<std::size_t>>{{0, 1, 2, 3, 4, 5, 6, 7, 8}}
+                },
+                dolfinx::fem::CoordinateElement(dolfinx::mesh::CellType::quadrilateral, 2),
+                std::vector{
+                    0., 0., 0.,
+                    1., 0., 0.,
+                    0., 1., 0.,
+                    1., 1., 0.,
+                    0.5, 0., 0.,
+                    0., 0.5, 0.,
+                    1., 0.5, 0.,
+                    0.5, 1., 0.,
+                    0.5, 0.5, 0.
+                },
+                {9, 3},
+                dolfinx::mesh::GhostMode::none
+            );
+    } else {
+        if (ct.value() == dolfinx::mesh::CellType::tetrahedron)
+            return dolfinx::mesh::create_mesh(
+                MPI_COMM_WORLD,
+                dolfinx::graph::AdjacencyList<std::int64_t>{
+                    std::vector<std::vector<std::size_t>>{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}
+                },
+                dolfinx::fem::CoordinateElement(
+                    dolfinx::mesh::CellType::tetrahedron,
+                    /*order*/2,
+                    basix::element::lagrange_variant::equispaced
+                ),
+                std::vector{
+                    0., 0., 0.,
+                    1., 0., 0.,
+                    0.5, 1., 0.,
+                    0.5, 0.0, 1.0,
+                    0.5, 0.5, 0.5,
+                    0.75, 0.0, 0.5,
+                    0.75, 0.5, 0.0,
+                    0.25, 0.0, 0.5,
+                    0.25, 0.5, 0.0,
+                    0.5, 0.0, 0.0
+                },
+                {10, 3},
+                dolfinx::mesh::GhostMode::none
+            );
+        else {  // hexahedron
+            std::vector<std::size_t> corners;
+            std::ranges::copy(std::views::iota(0, 27), std::back_inserter(corners));
+            return dolfinx::mesh::create_mesh(
+                MPI_COMM_WORLD,
+                dolfinx::graph::AdjacencyList<std::int64_t>{
+                    std::vector<std::vector<std::size_t>>{corners}
+                },
+                dolfinx::fem::CoordinateElement(dolfinx::mesh::CellType::hexahedron, 2),
+                std::vector{
+                    0., 0., 0.,
+                    1., 0., 0.,
+                    0., 1., 0.,
+                    1., 1., 0.,
+
+                    0., 0., 1.,
+                    1., 0., 1.,
+                    0., 1., 1.,
+                    1., 1., 1.,
+
+                    0.5, 0.0, 0.0, // 8
+                    0.0, 0.5, 0.0, // 9
+                    0.0, 0.0, 0.5, // 10
+
+                    1.0, 0.5, 0.0, // 11
+                    1.0, 0.0, 0.5, // 12
+                    0.5, 1.0, 0.0, // 13
+
+                    0.0, 1.0, 0.5, // 14
+                    1.0, 1.0, 0.5, // 15
+                    0.5, 0.0, 1.0, // 16
+
+                    0.0, 0.5, 1.0, // 17
+                    1.0, 0.5, 1.0, // 18
+                    0.5, 1.0, 1.0, // 19
+
+                    0.5, 0.5, 0.0, // 20
+                    0.5, 0.0, 0.5, // 21
+                    0.0, 0.5, 0.5, // 22
+
+                    1.0, 0.5, 0.5, // 23
+                    0.5, 1.0, 0.5, // 24
+                    0.5, 0.5, 1.0, // 25
+
+                    0.5, 0.5, 0.5  // 26
+                },
+                {27, 3},
+                dolfinx::mesh::GhostMode::none
+            );
+        }
+    }
+}
+
+bool is_sequential() {
+    return GridFormat::Parallel::size(MPI_COMM_WORLD) == 1;
+}
+
+std::string get_filename(dolfinx::mesh::CellType ct, const std::string& suffix = "") {
+    return "dolfinx_vtu" + (suffix.empty() ? "" : "_" + suffix) + "_"
+        + dolfinx::mesh::to_string(ct) + "_"
+        + std::to_string(dolfinx::mesh::cell_dim(ct)) + "d_in_3d";
+}
+
+template<typename Writer>
+void write_with(Writer writer, const std::string& filename) {
+    GridFormat::Test::add_meta_data(writer);
+    writer.set_point_field("pfunc", [&] (const auto& p) {
+        return GridFormat::Test::test_function<double>(GridFormat::coordinates(writer.grid(), p));
+    });
+    writer.set_cell_field("cfunc", [&] (const auto& p) {
+        std::array<double, 3> center;
+        std::ranges::fill(center, 0.0);
+        int corner_count = 0;
+        for (const auto& p : GridFormat::points(writer.grid(), p)) {
+            const auto pos = GridFormat::coordinates(writer.grid(), p);
+            for (int i = 0; i < 3; ++i)
+                center[i] += pos[i];
+            corner_count++;
+        }
+        std::ranges::for_each(center, [&] (auto& v) { v /= corner_count; });
+        return GridFormat::Test::test_function<double>(center);
+    });
+    const auto written_filename = writer.write(filename);
+    if (GridFormat::Parallel::rank(MPI_COMM_WORLD) == 0)
+        std::cout << "Wrote '" << written_filename << "'" << std::endl;
+}
+
+void write(const dolfinx::mesh::Mesh& mesh, std::string suffix = "") {
+    const auto added_suffix = suffix.empty() ? "" : "_" + suffix;
+    write_with(GridFormat::PVTUWriter{mesh, MPI_COMM_WORLD}, get_filename(mesh.topology().cell_type(), added_suffix));
+    if (is_sequential())
+        write_with(GridFormat::VTUWriter{mesh}, get_filename(mesh.topology().cell_type(), "sequential" + added_suffix));
+}
+
+template<int dim>
+void write() {
+    if constexpr (dim == 1) {
+        write(dolfinx::mesh::create_interval(MPI_COMM_WORLD, 5, {0., 1.0}));
+        write(dolfinx::mesh::create_interval(
+            MPI_COMM_WORLD, 5, {0., 1.0},
+            dolfinx::mesh::create_cell_partitioner(dolfinx::mesh::GhostMode::shared_facet)
+        ));
+        write(dolfinx::mesh::create_interval(
+            MPI_COMM_WORLD, 5, {0., 1.0},
+            dolfinx::mesh::create_cell_partitioner(dolfinx::mesh::GhostMode::shared_vertex)
+        ));
+
+        if (is_sequential())
+            write_with(
+                GridFormat::VTUWriter{higher_order_mesh<dim>()},
+                get_filename(dolfinx::mesh::CellType::interval, "higher_order")
+            );
+    }
+    if constexpr (dim == 2) {
+        auto min = GridFormat::Ranges::filled_array<dim>(0.0);
+        auto max = GridFormat::Ranges::filled_array<dim>(1.0);
+        for (auto ct : std::vector{dolfinx::mesh::CellType::triangle, dolfinx::mesh::CellType::quadrilateral}) {
+            write(dolfinx::mesh::create_rectangle(MPI_COMM_WORLD, {min, max}, {4, 4}, ct));
+            write(dolfinx::mesh::create_rectangle(
+                MPI_COMM_WORLD, {min, max}, {4, 4}, ct,
+                dolfinx::mesh::create_cell_partitioner(dolfinx::mesh::GhostMode::shared_facet)
+            ), "shared_facet");
+            write(dolfinx::mesh::create_rectangle(
+                MPI_COMM_WORLD, {min, max}, {4, 4}, ct,
+                dolfinx::mesh::create_cell_partitioner(dolfinx::mesh::GhostMode::shared_vertex)
+            ), "shared_vertex");
+
+            if (is_sequential())
+                write_with(
+                    GridFormat::VTUWriter{higher_order_mesh<dim>(ct)},
+                    get_filename(ct, "higher_order")
+                );
+        }
+    }
+    if constexpr (dim == 3) {
+        auto min = GridFormat::Ranges::filled_array<dim>(0.0);
+        auto max = GridFormat::Ranges::filled_array<dim>(1.0);
+        for (auto ct : std::vector{dolfinx::mesh::CellType::tetrahedron, dolfinx::mesh::CellType::hexahedron}) {
+            write(dolfinx::mesh::create_box(MPI_COMM_WORLD, {min, max}, {4, 4, 4}, ct));
+            write(dolfinx::mesh::create_box(
+                MPI_COMM_WORLD, {min, max}, {4, 4, 4}, ct,
+                dolfinx::mesh::create_cell_partitioner(dolfinx::mesh::GhostMode::shared_facet)
+            ), "shared_facet");
+            write(dolfinx::mesh::create_box(
+                MPI_COMM_WORLD, {min, max}, {4, 4, 4}, ct,
+                dolfinx::mesh::create_cell_partitioner(dolfinx::mesh::GhostMode::shared_vertex)
+            ), "shared_vertex");
+
+            if (is_sequential()) {
+                write_with(
+                    GridFormat::VTUWriter{higher_order_mesh<dim>(ct)}.with_encoding(GridFormat::Encoding::ascii),
+                    get_filename(ct, "higher_order")
+                );
+                dolfinx::io::VTKFile file{MPI_COMM_WORLD, std::string{"mesh_"} + dolfinx::mesh::to_string(ct) + ".pvd", "w"};
+                file.write(higher_order_mesh<dim>(ct), 0.0);
+            }
+        }
+    }
+}
+
+int main(int argc, char** argv) {
+    MPI_Init(&argc, &argv);
+    dolfinx::init_logging(argc, argv);
+
+    write<1>();
+    write<2>();
+    write<3>();
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/test/adapters/test_dolfinx.cpp
+++ b/test/adapters/test_dolfinx.cpp
@@ -331,6 +331,14 @@ int main(int argc, char** argv) {
     writer.set_point_field("pfunc_vec", [&] (const auto& p) { return out_mesh.evaluate<1>(vector_nodal_function, p); });
     writer.set_cell_field("cfunc", [&] (const auto& p) { return out_mesh.evaluate(scalar_cell_function, p); });
     writer.set_cell_field("cfunc_vec", [&] (const auto& p) { return out_mesh.evaluate<1>(vector_cell_function, p); });
+    GridFormat::DolfinX::set_point_field(scalar_nodal_function, writer, "pfunc_via_freefunction");
+    GridFormat::DolfinX::set_point_field(vector_nodal_function, writer, "pfunc_vec_via_freefunction");
+    GridFormat::DolfinX::set_cell_field(scalar_cell_function, writer, "cfunc_via_freefunction");
+    GridFormat::DolfinX::set_cell_field(vector_cell_function, writer, "cfunc_vec_via_freefunction");
+    GridFormat::DolfinX::set_field(scalar_nodal_function, writer, "pfunc_via_auto_freefunction");
+    GridFormat::DolfinX::set_field(vector_nodal_function, writer, "pfunc_vec_via_auto_freefunction");
+    GridFormat::DolfinX::set_field(scalar_cell_function, writer, "cfunc_via_auto_freefunction");
+    GridFormat::DolfinX::set_field(vector_cell_function, writer, "cfunc_vec_via_auto_freefunction");
     const auto filename = writer.write(get_filename(mesh->topology().cell_type(), "from_space"));
     if (GridFormat::Parallel::rank(MPI_COMM_WORLD) == 0)
         std::cout << "Wrote '" << filename << "'" << std::endl;

--- a/test/test_readme_tested_versions.py
+++ b/test/test_readme_tested_versions.py
@@ -15,6 +15,7 @@ def _get_pkg_versions_from_readme(readme_path: str) -> dict:
     result["dune"] = _split_version("dune")
     result["dealii"] = _split_version("deal.ii")
     result["cgal"] = _split_version("cgal")
+    result["dolfinx"] = _split_version("dolfinx")
     return result;
 
 
@@ -35,6 +36,7 @@ def _get_pkg_versions_from_cmake_log(cmake_log: str) -> dict:
     result["dune"] = _split_dune_version()
     result["dealii"] = _split_version("deal.ii")
     result["cgal"] = _split_version("CGAL")
+    result["dolfinx"] = _split_version("dolfinx")
     return result;
 
 


### PR DESCRIPTION
TODO:

- [x] we currently call `global_indices().size()`, which may involve some computation... an easier way to get the number of vertices (including ghosts) on a process must exist...
- [x] traits for `dolfinx::function`? To write higher-order elements... (done via function space traits)
- [x] proper introduction of higher-order cells
- [x] double-check api of `DolfinX::Mesh`
- [x] compatibility with master? (postponed, see #137)
- [x] add test with functionspace
- [x] remove obsolete detail functions
- [x] pyramids / prisms? (postponed, see #103 )
- [x] helper for adding fields from `dolfinx::fem::Function`?
- [x] discontinuous output from function spaces works?
- [x] add field setter for functions, which could check preconditions once upon setup, and then do the actual evaluation more efficient
