### PR TITLE
Feature/speedup ascii

### DIFF
--- a/gridformat/common/reserved_string.hpp
+++ b/gridformat/common/reserved_string.hpp
@@ -12,6 +12,7 @@
 #include <string_view>
 #include <algorithm>
 #include <ostream>
+#include <format>
 
 #include <gridformat/common/exceptions.hpp>
 
@@ -91,5 +92,13 @@ template<std::size_t N>
 ReservedString(const char (&input)[N]) -> ReservedString<N-1>;
 
 }  // namespace GridFormat
+
+// specialize std::formatter for GridFormat::ReservedString
+template <std::size_t n>
+struct std::formatter<GridFormat::ReservedString<n>> : std::formatter<std::string_view> {
+    auto format(const GridFormat::ReservedString<n>& s, std::format_context& ctx) const {
+        return std::formatter<std::string_view>::format(static_cast<std::string_view>(s), ctx);
+    }
+};
 
 #endif  // GRIDFORMAT_COMMON_RESERVED_STRING_HPP_

--- a/gridformat/common/reserved_string.hpp
+++ b/gridformat/common/reserved_string.hpp
@@ -12,7 +12,10 @@
 #include <string_view>
 #include <algorithm>
 #include <ostream>
+
+#if __has_include(<format>)
 #include <format>
+#endif
 
 #include <gridformat/common/exceptions.hpp>
 
@@ -93,6 +96,7 @@ ReservedString(const char (&input)[N]) -> ReservedString<N-1>;
 
 }  // namespace GridFormat
 
+#if __cpp_lib_format
 // specialize std::formatter for GridFormat::ReservedString
 template <std::size_t n>
 struct std::formatter<GridFormat::ReservedString<n>> : std::formatter<std::string_view> {
@@ -100,5 +104,6 @@ struct std::formatter<GridFormat::ReservedString<n>> : std::formatter<std::strin
         return std::formatter<std::string_view>::format(static_cast<std::string_view>(s), ctx);
     }
 };
+#endif
 
 #endif  // GRIDFORMAT_COMMON_RESERVED_STRING_HPP_


### PR DESCRIPTION
Fix #170 

results from local testing:
std::format: 5.3753 seconds
std::ostringstream: 8.68944 seconds
before: 9.99393 seconds
dune: 12.4421 seconds