### PR TITLE
Feature/cli enhance converter

### DIFF
--- a/bin/common.hpp
+++ b/bin/common.hpp
@@ -6,6 +6,7 @@
 
 #include <ranges>
 #include <algorithm>
+#include <optional>
 
 namespace GridFormat::Apps {
 
@@ -15,6 +16,20 @@ bool args_ask_for_help(int argc, char** argv) {
         | std::views::transform([&] (int i) { return std::string{argv[i]}; }),
         [] (const std::string& arg) { return arg == "--help"; }
     );
+}
+
+std::string wrapped(std::string word, std::string prefix, std::optional<std::string> suffix = {}) {
+    auto suffix_str = std::move(suffix).value_or(prefix);
+    prefix.reserve(prefix.size() + word.size() + suffix_str.size());
+    std::ranges::move(std::move(word), std::back_inserter(prefix));
+    std::ranges::move(std::move(suffix_str), std::back_inserter(prefix));
+    return prefix;
+}
+
+std::string as_cell(std::string word, std::size_t count = 20) {
+    if (word.size() < count)
+        word.resize(count, ' ');
+    return word;
 }
 
 }  // namespace GridFormat::Apps

--- a/bin/convert.cpp
+++ b/bin/convert.cpp
@@ -277,14 +277,13 @@ void convert_file(std::string in_filename,
     bool is_rank_0 = GridFormat::Parallel::rank(c) == 0;
     auto options_map = make_options_map(opts | std::views::all);
     FormatSelector::with(out_fmt, [&] <typename Format> (Format fmt) {
-        FormatSelector::with(in_fmt, [&] <typename InFormat> (InFormat in_fmt) {
+        FormatSelector::with(in_fmt, [&] <typename InFormat> (InFormat) {
             auto fmt_opts = OptionsParser<Format>::parse(options_map);
             if constexpr (ExposesOptions<Format>)
                 fmt.opts = fmt_opts;
 
-            const GridFormat::ConversionOptions conversion_opts{
+            const GridFormat::ConversionOptions<Format, InFormat> conversion_opts{
                 .out_format = fmt,
-                .in_format = in_fmt,
                 .verbosity = (
                     quiet ? 0 : (
                         is_rank_0 ? 2 : (

--- a/bin/convert.cpp
+++ b/bin/convert.cpp
@@ -4,8 +4,10 @@
 #include <unordered_map>
 #include <filesystem>
 #include <type_traits>
+#include <algorithm>
 #include <iterator>
 #include <iostream>
+#include <optional>
 #include <utility>
 #include <ranges>
 
@@ -57,7 +59,7 @@ using OptionsMap = std::unordered_map<std::string, std::string>;
 auto split_key_and_value(const std::string& key_value_pair) {
     auto split_pos = key_value_pair.find("=");
     if (split_pos == std::string::npos || split_pos == key_value_pair.size() - 1)
-        throw std::runtime_error("Could not parse option from string '" + key_value_pair + "'");
+        throw std::runtime_error("Could not parse option (in the form key=value) from string '" + key_value_pair + "'");
     return std::make_pair(key_value_pair.substr(0, split_pos), key_value_pair.substr(split_pos + 1));
 }
 
@@ -91,7 +93,7 @@ template<typename Options = GridFormat::None>
 struct OptsParser {
     static auto parse(const OptionsMap& opts) {
         if (GridFormat::Ranges::size(opts) != 0)
-            throw std::runtime_error("Format does not take any options");
+            throw std::runtime_error("Error: chosen format does not take any options");
         return GridFormat::none;
     }
 
@@ -182,7 +184,9 @@ using OptionsParser = typename OptionsParserSelector<Format>::type;
 struct FormatSelector {
     template<typename Action>
     static void with(const std::string& fmt, const Action& action) {
-        if (fmt == "vtu")
+        if (fmt == "any")
+            action(GridFormat::any);
+        else if (fmt == "vtu")
             action(GridFormat::vtu);
         else if (fmt == "vti")
             action(GridFormat::vti);
@@ -201,62 +205,162 @@ struct FormatSelector {
     }
 
     static std::vector<std::string> supported_formats() {
-        return std::vector<std::string>{"vtu", "vti", "vtr", "vts", "vtk-hdf"};
+        return std::vector<std::string>{"vtu", "vti", "vtr", "vts", "vtk-hdf", "any"};
     }
 };
 
 template<GridFormat::Concepts::Communicator Communicator>
-void convert_file(const std::string& in_filename,
+void convert_file(std::string in_filename,
                   const std::string& out_fmt,
                   const Communicator& c,
                   std::vector<std::string> opts) {
+
+    // (maybe) adjust input file name
+    bool rank_specific_files = false;
+    if (auto pos = in_filename.find("{RANK}"); pos != std::string::npos) {
+        in_filename.replace(pos, 6, std::to_string(GridFormat::Parallel::rank(c)));
+        rank_specific_files = true;
+    } else if (auto pos = in_filename.find("{RANK:"); pos != std::string::npos) {
+        auto width_pos = pos + 6;
+        auto end = in_filename.find_first_of("}", width_pos);
+        if (end == std::string::npos)
+            throw std::runtime_error("Invalid rank placeholder");
+        const auto width = GridFormat::from_string<int>(in_filename.substr(width_pos, end-width_pos));
+        if (width <= 0)
+            throw std::runtime_error("Invalid rank placeholder width");
+        auto rank_str = GridFormat::as_string(GridFormat::Parallel::rank(c));
+        const int replace_width = width - rank_str.size();
+        rank_str.insert(0, (replace_width <= 0 ? 0 : replace_width), '0');
+        in_filename.replace(pos, end + 1 - pos, rank_str);
+        rank_specific_files = true;
+    }
+
     std::filesystem::path in_path{in_filename};
     if (!std::filesystem::exists(in_path))
         throw std::runtime_error("Given file '" + in_filename + "' does not exist.");
 
-    std::string out_filename = (in_path.parent_path() / in_path.stem()).string() + "_converted";
-    if (auto it = std::ranges::find(opts, "-o"); it != opts.end()) {
-        auto out_name_it = it;
-        if (++out_name_it; out_name_it == std::ranges::end(opts))
-            throw std::runtime_error("No filename given after '-o'");
-        out_filename = *out_name_it;
-        ++out_name_it;
-        opts.erase(it, out_name_it);
-    }
-    if (auto it = std::ranges::find(opts, "-o"); it != opts.end())
-        throw std::runtime_error("Option '-o' given multiple times");
+    const auto parse_arg = [&] (const std::string& short_key, const std::string& long_key) -> std::optional<std::string> {
+        const auto process = [&] (const std::string& key) -> std::optional<std::string> {
+            if (auto it = std::ranges::find(opts, key); it != opts.end()) {
+                auto value_it = it;
+                if (++value_it; value_it == opts.end())
+                    throw std::runtime_error("Missing value for option '" + key + "'.");
+                std::string result = *value_it;
+                opts.erase(it, ++value_it);
+                return result;
+            }
+            return {};
+        };
+        if (auto result = process(short_key); result) return result;
+        if (auto result = process(long_key); result) return result;
+        return {};
+    };
+    const auto parse_single_arg = [&] (const std::string& short_key, const std::string& long_key) -> std::optional<std::string> {
+        if (auto result = parse_arg(short_key, long_key); result) {
+            if (std::ranges::find(opts, short_key) != opts.end() || std::ranges::find(opts, long_key) != opts.end())
+                throw std::runtime_error("Option '" + short_key + " | " + long_key + "' given multiple times");
+            return result;
+        }
+        return {};
+    };
 
+    std::string out_filename = (in_path.parent_path() / in_path.stem()).string() + "_converted";
+    if (auto f = parse_single_arg("-o", "--out-filename"); f) out_filename = f.value();
+
+    std::string in_fmt = "any";
+    if (auto f = parse_single_arg("-i", "--input-format"); f) in_fmt = f.value();
+
+    bool quiet = false;
+    if (auto it = std::ranges::find(opts, "-q"); it != opts.end()) { opts.erase(it); quiet = true; }
+    if (auto it = std::ranges::find(opts, "--quiet"); it != opts.end()) { opts.erase(it); quiet = true; }
+
+    bool is_rank_0 = GridFormat::Parallel::rank(c) == 0;
     auto options_map = make_options_map(opts | std::views::all);
     FormatSelector::with(out_fmt, [&] <typename Format> (Format fmt) {
-        auto fmt_opts = OptionsParser<Format>::parse(options_map);
-        if constexpr (ExposesOptions<Format>)
-            fmt.opts = fmt_opts;
+        FormatSelector::with(in_fmt, [&] <typename InFormat> (InFormat in_fmt) {
+            auto fmt_opts = OptionsParser<Format>::parse(options_map);
+            if constexpr (ExposesOptions<Format>)
+                fmt.opts = fmt_opts;
 
-        if (std::is_same_v<Communicator, GridFormat::NullCommunicator> || GridFormat::Parallel::size(c) == 1)
-            GridFormat::convert(in_filename, out_filename, fmt);
-        else
-            GridFormat::convert(in_filename, out_filename, fmt, c);
+            const GridFormat::ConversionOptions conversion_opts{
+                .out_format = fmt,
+                .in_format = in_fmt,
+                .verbosity = (
+                    quiet ? 0 : (
+                        is_rank_0 ? 2 : (
+                            rank_specific_files ? 1 : 0
+                        )
+                    )
+                )
+            };
+
+            const auto written_file = [&] () {
+                if (std::is_same_v<Communicator, GridFormat::NullCommunicator> || GridFormat::Parallel::size(c) == 1)
+                    return GridFormat::convert(in_filename, out_filename, conversion_opts);
+                else
+                    return GridFormat::convert(in_filename, out_filename, conversion_opts, c);
+            } ();
+        });
     });
 }
 
 void print_help() {
-    std::cout << "usage: gridformat-convert FILE TARGET_FORMAT [TARGET_FORMAT_OPTIONS] [-o OUT_FILENAME]\n" << std::endl;
-    std::cout << "'TARGET_FORMAT' can be any of: {"
-              << GridFormat::as_string(FormatSelector::supported_formats(), ", ")
-              << "}" << std::endl
-              << "'TARGET_FORMAT_OPTIONS' are pairs of 'key=value'. "
-              << "Use gridformat-convert --help-TARGET_FORMAT for more info." << std::endl
-              << "'OUT_FILENAME' defaults to FILE_WITHOUT_EXTENSION_converted.NEW_EXTENSION" << std::endl
-              << "\nImportant: input & output filenames cannot be the same as data is read/written lazily." << std::endl;
+    const auto print_arg_line = [] (std::string arg, std::string description) {
+        static constexpr std::size_t arg_width = 25;
+        static constexpr std::size_t indentation = 25 + 4;
+        std::cout << GridFormat::Apps::as_cell(std::move(arg), arg_width) << std::string(4, ' ');
+        int i = 0;
+        for (const auto& description_line : description | std::views::split('\n')) {
+            std::cout << (i++ > 0 ? std::string(indentation, ' ') : std::string{})
+                      << std::string{std::ranges::begin(description_line), std::ranges::end(description_line)}
+                      << std::endl;
+        }
+        std::cout << std::endl;
+    };
+
+    std::cout << "usage: [mpirun -n NUM_RANKS] gridformat-convert FILE TARGET_FORMAT [TARGET_FORMAT_OPTIONS] "
+              << "[-o | --out-filename OUT_FILENAME] [-q --quiet] [-i --input-format]" << std::endl;
+    std::cout << std::endl;
+    print_arg_line(
+        "FILE",
+        "The file to be converted. May contain '{RANK}', a placeholder that is substituted\n"
+        "by the process rank and which allows you to read different files per process (e.g. to\n"
+        "merge them into one parallel file). Use '{RANK:N}' in order to specify a fixed width\n"
+        "that is filled with leading zeros. For instance: '{RANK:3}' will yield 001 on rank 0."
+    );
+    print_arg_line(
+        "TARGET_FORMAT",
+        "Specify the format into which to convert. Can be any of {"
+        + GridFormat::as_string(FormatSelector::supported_formats(), ", ")
+        + "}.\nNote: if 'any' is selected, gridformat will select a default format."
+    );
+    print_arg_line(
+        "TARGET_FORMAT_OPTIONS",
+        "Specify further options for the chosen TARGET_FORMAT as pairs of 'key=value'.\n"
+        "Use 'gridformat-convert --help-TARGET_FORMAT for more info."
+    );
+    print_arg_line(
+        "-o | --out-filename",
+        "The name of the file to be written (without extension).\n"
+        "Defaults to '${FILE*}_converted.NEW_EXTENSION'., where FILE* is the name of\n"
+        "the given file without the extension."
+    );
+    print_arg_line("-q | --quiet", "Use this flag to suppress progress output.");
+    print_arg_line(
+        "-i | --input-format",
+        "Specify the format of FILE. If unspecified, it is deduced from its extension.\n"
+        "See 'TARGET_FORMAT' for the available format specifiers."
+    );
+    std::cout << "Important: input & output filenames cannot be the same since data is read/written lazily to reduce memory usage." << std::endl;
 }
 
 void print_format_help(const std::string& format) {
     FormatSelector::with(format, [&] <typename Fmt> (const Fmt&) {
         const auto all_opts = OptionsParser<Fmt>::get_all_opts();
         if (all_opts.empty()) {
-            std::cout << "Format '" << format << "' takes no options" << std::endl;
+            std::cout << "[gridformat-convert]: Format '" << format << "' takes no options" << std::endl;
         } else {
-            std::cout << "Format '" << format << "' accepts the following options:" << std::endl;
+            std::cout << "[gridformat-convert]: Format '" << format << "' accepts the following options:" << std::endl;
             print_options(all_opts);
         }
     });

--- a/bin/info.cpp
+++ b/bin/info.cpp
@@ -10,20 +10,6 @@
 #include <gridformat/gridformat.hpp>
 #include "common.hpp"
 
-std::string wrapped(std::string word, std::string prefix, std::optional<std::string> suffix = {}) {
-    auto suffix_str = std::move(suffix).value_or(prefix);
-    prefix.reserve(prefix.size() + word.size() + suffix_str.size());
-    std::ranges::move(std::move(word), std::back_inserter(prefix));
-    std::ranges::move(std::move(suffix_str), std::back_inserter(prefix));
-    return prefix;
-}
-
-std::string as_cell(std::string word, std::size_t count = 20) {
-    if (word.size() < count)
-        word.resize(count, ' ');
-    return word;
-}
-
 template<std::ranges::range R>
 void print_fields_info(R&& field_range) {
     std::vector<std::string> names;
@@ -40,6 +26,8 @@ void print_fields_info(R&& field_range) {
         return a.size() < b.size();
     })->size();
 
+    using GridFormat::Apps::as_cell;
+    using GridFormat::Apps::wrapped;
     for (unsigned int i = 0; i < names.size(); ++i)
         std::cout << " - " << as_cell(wrapped(names[i], "'"), max_cell_width + 3)
                            << " shape=(" << shapes[i] << ")"
@@ -54,6 +42,7 @@ void print_file_info(const std::string& filename) {
     GridFormat::Reader reader;
     reader.open(filename);
 
+    using GridFormat::Apps::as_cell;
     std::cout << as_cell("Filename:" ) << filename << std::endl;
     std::cout << as_cell("Reader:") << reader.name() << std::endl;
     std::cout << as_cell("Number of cells:")  << reader.number_of_cells() << std::endl;

--- a/bin/info.cpp
+++ b/bin/info.cpp
@@ -54,6 +54,9 @@ void print_file_info(const std::string& filename) {
 
     std::cout << "Point fields:" << std::endl;
     print_fields_info(point_fields(reader));
+
+    std::cout << "Meta data fields:" << std::endl;
+    print_fields_info(meta_data_fields(reader));
 }
 
 void print_help() {

--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -42,6 +42,7 @@ INPUT                 += @CMAKE_SOURCE_DIR@/README.md \
                          @CMAKE_SOURCE_DIR@/@PROJECT_NAME@/grid/concepts.hpp \
                          @CMAKE_SOURCE_DIR@/@PROJECT_NAME@/grid/converter.hpp \
                          @CMAKE_SOURCE_DIR@/@PROJECT_NAME@/grid/writer.hpp \
+                         @CMAKE_SOURCE_DIR@/@PROJECT_NAME@/grid/reader.hpp \
                          @CMAKE_SOURCE_DIR@/@PROJECT_NAME@/vtk/ \
                          @CMAKE_SOURCE_DIR@/@PROJECT_NAME@/encoding/ \
                          @CMAKE_SOURCE_DIR@/@PROJECT_NAME@/compression/ \

--- a/gridformat/common/hdf5.hpp
+++ b/gridformat/common/hdf5.hpp
@@ -500,7 +500,8 @@ class File {
 
     template<typename T, typename Source>
     auto _read_buffer_field(const Source& source) const {
-        MDLayout layout{source.getMemSpace().getDimensions()};
+        auto dims = source.getMemSpace().getDimensions();
+        MDLayout layout = dims.empty() ? MDLayout{{1}} : MDLayout{std::move(dims)};
         std::vector<T> out(layout.number_of_entries());
         source.read(out.data());
         return BufferField(std::move(out), std::move(layout));

--- a/gridformat/common/md_layout.hpp
+++ b/gridformat/common/md_layout.hpp
@@ -65,6 +65,8 @@ class MDLayout {
     }
 
     std::size_t number_of_entries() const {
+        if (dimension() == 0)
+            return 0;
         return std::accumulate(
             _extents.begin(),
             _extents.end(),

--- a/gridformat/common/md_layout.hpp
+++ b/gridformat/common/md_layout.hpp
@@ -15,6 +15,7 @@
 #include <iterator>
 #include <algorithm>
 #include <initializer_list>
+#include <type_traits>
 #include <string>
 
 #include <gridformat/common/reserved_vector.hpp>
@@ -37,7 +38,10 @@ class MDLayout {
     template<Concepts::MDRange<1> R>
     explicit MDLayout(R&& extents) {
         _extents.reserve(Ranges::size(extents));
-        std::ranges::copy(extents, std::back_inserter(_extents));
+        if constexpr (!std::is_lvalue_reference_v<R>)
+            std::ranges::move(std::move(extents), std::back_inserter(_extents));
+        else
+            std::ranges::copy(extents, std::back_inserter(_extents));
     }
 
     template<std::integral T>
@@ -134,7 +138,7 @@ namespace Detail {
 template<typename T> requires(Concepts::StaticallySizedRange<T> or Concepts::Scalar<T>)
 MDLayout get_md_layout() {
     if constexpr (Concepts::Scalar<T>)
-        return MDLayout{};
+        return MDLayout{{1}};
     else {
         std::array<std::size_t, mdrange_dimension<T>> extents;
         extents[0] = static_size<T>;
@@ -176,7 +180,7 @@ MDLayout get_md_layout(R&& r) {
  */
 template<Concepts::Scalar T>
 MDLayout get_md_layout(const T&) {
-    return MDLayout{};
+    return MDLayout{{1}};
 }
 
 }  // namespace GridFormat

--- a/gridformat/common/serialization.hpp
+++ b/gridformat/common/serialization.hpp
@@ -63,7 +63,7 @@ class Serialization {
 
     void cut_front(std::size_t number_of_bytes) {
         if (number_of_bytes > size())
-            throw ValueError("Cannot cut more bytes than stored");
+            throw SizeError("Cannot cut more bytes than stored");
         const auto new_size = _data.size() - number_of_bytes;
         std::span trail{_data.data() + number_of_bytes, new_size};
         std::ranges::move(trail, _data.begin());

--- a/gridformat/grid/converter.hpp
+++ b/gridformat/grid/converter.hpp
@@ -154,7 +154,7 @@ std::string convert(Reader& reader,
                     const Factory& factory,
                     const StepCallBack& call_back = {}) {
     if (!reader.is_sequence())
-        throw ValueError("Cannot convert data from reader to a sequence as reader is no sequence.");
+        throw ValueError("Cannot convert data from reader to a sequence as the file read is no sequence.");
 
     ConverterDetail::ConverterGrid grid{reader};
     auto writer = factory(grid);

--- a/gridformat/grid/reader.hpp
+++ b/gridformat/grid/reader.hpp
@@ -96,7 +96,8 @@ class GridReader {
         return _number_of_points();
     }
 
-    //! Return the number of pieces read from the file (may be > 1 for parallel file formats)
+    //! Return the number of pieces contained in the read file (when constructing readers
+    //! in parallel, this reader instance contains the data of only one or some of these pieces)
     std::size_t number_of_pieces() const {
         return _number_of_pieces();
     }

--- a/gridformat/grid/reader.hpp
+++ b/gridformat/grid/reader.hpp
@@ -22,6 +22,7 @@
 #include <gridformat/common/ranges.hpp>
 #include <gridformat/common/exceptions.hpp>
 #include <gridformat/common/concepts.hpp>
+#include <gridformat/common/logging.hpp>
 #include <gridformat/grid/cell_type.hpp>
 
 namespace GridFormat::Concepts {
@@ -251,6 +252,10 @@ class GridReader {
         });
     }
 
+    void set_ignore_warnings(bool value) {
+        _ignore_warnings = value;
+    }
+
  protected:
     struct FieldNames {
         std::vector<std::string> cell_fields;
@@ -264,9 +269,19 @@ class GridReader {
         }
     };
 
+    void _log_warning(std::string_view warning) const {
+        if (!_ignore_warnings)
+            log_warning(
+                std::string{warning}
+                + (warning.ends_with("\n") ? "" : "\n")
+                + "To deactivate this warning, call set_ignore_warnings(true);"
+            );
+    }
+
  private:
     std::string _filename = "";
     FieldNames _field_names;
+    bool _ignore_warnings = false;
 
     virtual std::string _name() const = 0;
     virtual void _open(const std::string&, FieldNames&) = 0;

--- a/gridformat/gridformat.hpp
+++ b/gridformat/gridformat.hpp
@@ -970,7 +970,7 @@ std::unique_ptr<GridReader> AnyReaderFactory<C>::make_for(const std::string& fil
 //! Options for format conversions
 template<typename OutFormat, typename InFormat = FileFormat::Any>
 struct ConversionOptions {
-    OutFormat out_format;
+    OutFormat out_format = {};
     InFormat in_format = {};
     int verbosity = 0;
 };

--- a/gridformat/gridformat.hpp
+++ b/gridformat/gridformat.hpp
@@ -930,13 +930,10 @@ namespace APIDetail {
     template<std::derived_from<GridReader> Reader, typename Communicator>
     std::unique_ptr<Reader> make_reader(const Communicator& c) {
         if constexpr (std::is_same_v<Communicator, NullCommunicator> ||
-                        !std::is_constructible_v<Reader, const Communicator&>) {
-            if (Parallel::size(c) > 1)
-                throw ValueError("Cannot construct given reader for parallel I/O");
+                        !std::is_constructible_v<Reader, const Communicator&>)
             return std::make_unique<Reader>();
-        } else {
+        else
             return std::make_unique<Reader>(c);
-        }
     }
 
     template<Concepts::Communicator C>

--- a/gridformat/gridformat.hpp
+++ b/gridformat/gridformat.hpp
@@ -924,11 +924,10 @@ namespace APIDetail {
             || filename.ends_with(".h5");
     }
 
-    template<std::derived_from<GridReader> Reader, typename Communicator = NullCommunicator>
-    std::unique_ptr<Reader> make_reader(const Communicator& c = {}) {
+    template<std::derived_from<GridReader> Reader, typename Communicator>
+    std::unique_ptr<Reader> make_reader(const Communicator& c) {
         if constexpr (std::is_same_v<Communicator, NullCommunicator> ||
                         !std::is_constructible_v<Reader, const Communicator&>) {
-            // if we get here although the communicator size is > 1, something probably went wrong
             if (Parallel::size(c) > 1)
                 throw ValueError("Cannot construct given reader for parallel I/O");
             return std::make_unique<Reader>();

--- a/gridformat/parallel/traits.hpp
+++ b/gridformat/parallel/traits.hpp
@@ -127,7 +127,7 @@ struct Gather<NullCommunicator> {
     }
 
     template<Concepts::Scalar T>
-    static constexpr std::vector<T>& get(const NullCommunicator&, const std::vector<T>& vec, [[maybe_unused]] int root_rank = 0) {
+    static constexpr const std::vector<T>& get(const NullCommunicator&, const std::vector<T>& vec, [[maybe_unused]] int root_rank = 0) {
         return vec;
     }
 

--- a/gridformat/vtk/hdf_image_grid_reader.hpp
+++ b/gridformat/vtk/hdf_image_grid_reader.hpp
@@ -66,8 +66,8 @@ class VTKHDFImageGridReader : public GridReader {
 
         VTKHDF::check_version_compatibility(_file.value(), {2, 0});
 
-        if (_file->exists("VTKHDF/Steps"))
-            _file->visit_attribute("VTKHDF/Steps/NSteps", [&] (auto&& field) {
+        if (_file->exists("/VTKHDF/Steps"))
+            _file->visit_attribute("/VTKHDF/Steps/NSteps", [&] (auto&& field) {
                 _num_steps.emplace();
                 field.export_to(_num_steps.value());
                 _step_index.emplace(0);

--- a/gridformat/vtk/hdf_unstructured_grid_reader.hpp
+++ b/gridformat/vtk/hdf_unstructured_grid_reader.hpp
@@ -216,9 +216,7 @@ class VTKHDFUnstructuredGridReader : public GridReader {
     }
 
     std::size_t _number_of_pieces() const override {
-        if (Parallel::size(_comm) > 1)
-            return _number_of_pieces_in_file();
-        return 1;
+        return _number_of_pieces_in_file();
     }
 
     std::size_t _number_of_pieces_in_file() const {

--- a/gridformat/vtk/pxml_reader.hpp
+++ b/gridformat/vtk/pxml_reader.hpp
@@ -90,6 +90,7 @@ class PXMLReaderBase : public GridReader {
     XMLReaderHelper _read_pvtk_file(const std::string& filename, typename GridReader::FieldNames& fields) {
         _filename = filename;
          auto helper = XMLReaderHelper::make_from(filename, _vtk_grid_type);
+        _num_pieces_in_file = Ranges::size(_pieces_paths(helper));
         _read_pieces(helper);
         if (_piece_readers.size() > 0) {
             std::ranges::copy(point_field_names(_piece_readers.front()), std::back_inserter(fields.point_fields));
@@ -111,6 +112,7 @@ class PXMLReaderBase : public GridReader {
     void _close_pvtk_file() {
         _filename.reset();
         _piece_readers.clear();
+        _num_pieces_in_file = 0;
     }
 
  private:
@@ -134,7 +136,7 @@ class PXMLReaderBase : public GridReader {
     }
 
     std::size_t _number_of_pieces() const override {
-        return _num_ranks.value_or(std::size_t{1});
+        return _num_pieces_in_file;
     }
 
     bool _is_sequence() const override {
@@ -232,6 +234,7 @@ class PXMLReaderBase : public GridReader {
 
     std::optional<std::string> _filename;
     std::vector<PieceReader> _piece_readers;
+    std::size_t _num_pieces_in_file = 0;
 };
 
 

--- a/gridformat/vtk/pxml_reader.hpp
+++ b/gridformat/vtk/pxml_reader.hpp
@@ -214,7 +214,7 @@ class PXMLReaderBase : public GridReader {
 
         const bool is_last_rank = _rank.value() == _num_ranks.value() - 1;
         const bool merge_final_pieces = is_last_rank && _merge_exceeding.value_or(false);
-        const std::size_t my_num_pieces = merge_final_pieces ? _num_ranks.value() - _rank.value() : 1;
+        const std::size_t my_num_pieces = merge_final_pieces ? Ranges::size(_pieces_paths(helper)) - _rank.value() : 1;
 
         std::ranges::for_each(
             _pieces_paths(helper)

--- a/gridformat/vtk/pxml_reader.hpp
+++ b/gridformat/vtk/pxml_reader.hpp
@@ -26,7 +26,6 @@
 #include <gridformat/common/empty_field.hpp>
 #include <gridformat/common/field_transformations.hpp>
 #include <gridformat/common/exceptions.hpp>
-#include <gridformat/common/logging.hpp>
 
 #include <gridformat/grid/reader.hpp>
 #include <gridformat/parallel/communication.hpp>
@@ -203,11 +202,11 @@ class PXMLReaderBase : public GridReader {
     void _read_parallel_piece(const XMLReaderHelper& helper) {
         const auto num_pieces = Ranges::size(_pieces_paths(helper));
         if (num_pieces < _num_ranks.value() && _rank.value() == 0)
-            log_warning(
+            this->_log_warning(
                 "PVTK file defines less pieces than there are ranks. The grids on some ranks will be empty."
             );
         if (num_pieces > _num_ranks.value() && !_merge_exceeding.has_value() && _rank.value() == 0)
-            log_warning(
+            this->_log_warning(
                 "PVTK file defines more pieces than used ranks. Will only read the first "
                 + std::to_string(_num_ranks.value()) + " pieces"
             );

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -174,6 +174,7 @@ if (GRIDFORMAT_DO_COVERAGE)
 endif ()
 
 add_subdirectory(common)
+add_subdirectory(parallel)
 add_subdirectory(compression)
 add_subdirectory(encoding)
 add_subdirectory(grid)

--- a/test/api/test_generic_converter.cpp
+++ b/test/api/test_generic_converter.cpp
@@ -52,9 +52,9 @@ void test(const Grid& grid,
     const auto out_filename = filename_prefix() + suffix + "_out_2d_in_2d";
     const auto converted = [&] () {
         if constexpr (is_parallel)
-            return GridFormat::convert(in_filename, out_filename, GridFormat::ConversionOptions{.out_format = out_fmt}, comm);
+            return GridFormat::convert(in_filename, out_filename, GridFormat::ConversionOptions<OutFmt>{}, comm);
         else
-            return GridFormat::convert(in_filename, out_filename, GridFormat::ConversionOptions{.out_format = out_fmt});
+            return GridFormat::convert(in_filename, out_filename, GridFormat::ConversionOptions<OutFmt>{});
     } ();
     std::cout << "Wrote '" << converted << "'" << std::endl;
 
@@ -130,10 +130,10 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
         return _ts_filename;
     } ();
 
-    const auto convert_time_series_to = [&] (const auto& out_format, const std::string& out_name) {
+    const auto convert_time_series_to = [&] <typename O> (const O&, const std::string& out_name) {
         return is_parallel
-            ? GridFormat::convert(ts_filename, out_name, GridFormat::ConversionOptions{.out_format = out_format}, comm)
-            : GridFormat::convert(ts_filename, out_name, GridFormat::ConversionOptions{.out_format = out_format});
+            ? GridFormat::convert(ts_filename, out_name, GridFormat::ConversionOptions<O>{}, comm)
+            : GridFormat::convert(ts_filename, out_name, GridFormat::ConversionOptions<O>{});
     };
 
     const auto ts_converted_filename = convert_time_series_to(

--- a/test/api/test_generic_converter.cpp
+++ b/test/api/test_generic_converter.cpp
@@ -52,9 +52,9 @@ void test(const Grid& grid,
     const auto out_filename = filename_prefix() + suffix + "_out_2d_in_2d";
     const auto converted = [&] () {
         if constexpr (is_parallel)
-            return GridFormat::convert(in_filename, out_filename, out_fmt, comm);
+            return GridFormat::convert(in_filename, out_filename, GridFormat::ConversionOptions{.out_format = out_fmt}, comm);
         else
-            return GridFormat::convert(in_filename, out_filename, out_fmt);
+            return GridFormat::convert(in_filename, out_filename, GridFormat::ConversionOptions{.out_format = out_fmt});
     } ();
     std::cout << "Wrote '" << converted << "'" << std::endl;
 
@@ -132,8 +132,15 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
 
     const auto ts_converted_filename_base = "generic_" + parallel_suffix + "time_series_converter_2d_in_2d";
     const auto ts_converted_filename = is_parallel
-        ? GridFormat::convert(ts_filename, ts_converted_filename_base, GridFormat::pvd_with(GridFormat::vtu), comm)
-        : GridFormat::convert(ts_filename, ts_converted_filename_base, GridFormat::pvd_with(GridFormat::vtu));
+        ? GridFormat::convert(
+            ts_filename, ts_converted_filename_base,
+            GridFormat::ConversionOptions{.out_format = GridFormat::pvd_with(GridFormat::vtu)},
+            comm
+        )
+        : GridFormat::convert(
+            ts_filename, ts_converted_filename_base,
+            GridFormat::ConversionOptions{.out_format = GridFormat::pvd_with(GridFormat::vtu)}
+        );
 
     if (rank == 0)
         std::cout << "Wrote converted time series to '" << ts_converted_filename << "'" << std::endl;

--- a/test/api/test_generic_converter.cpp
+++ b/test/api/test_generic_converter.cpp
@@ -106,6 +106,21 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
     };
 #endif
 
+    // test merging of sequential files into one parallel file
+    if (is_parallel)
+        "generic_converter_sequential_to_parallel"_test = [&] () {
+            GridFormat::VTUWriter sequential_writer{grid};
+            const auto seq_file = sequential_writer.write("_generic_converter_vtu_per_rank-" + std::to_string(rank));
+            const auto converted_parallel_file = GridFormat::convert(
+                seq_file,
+                "generic_parallel_converter_sequential_files_to_parallel_file_2d_in_2d_out",
+                GridFormat::ConversionOptions<GridFormat::FileFormat::VTU>{},
+                comm
+            );
+            if (rank == 0)
+                std::cout << "Wrote sequential file converted to parallel '" << converted_parallel_file << "'" << std::endl;
+        };
+
     // test time series conversion
     const auto parallel_suffix = is_parallel ? std::string{"parallel_"} : std::string{""};
     const auto ts_in_filename = "generic_" + parallel_suffix + "ts_converter_in";

--- a/test/api/test_generic_reader.cpp
+++ b/test/api/test_generic_reader.cpp
@@ -280,12 +280,19 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
         test_reader(generated_data_folder, ".pvd", GridFormat::any);
     }
 
+    using GridFormat::Testing::operator""_test;
+    using GridFormat::Testing::expect;
+    using GridFormat::Testing::throws;
+    using GridFormat::Testing::eq;
+
+    "generic_reader_throws_on_non_matching_format"_test = [&] () {
+        GridFormat::Reader r{GridFormat::vtr};
+        r.open(vtr_filename);
+        GridFormat::Testing::expect(throws<GridFormat::IOError>([&] () { r.open(vti_filename); }));
+    };
+
     // check that reader exposes image/rectilinear grid-specific interfaces
     if (!is_parallel) {
-        using GridFormat::Testing::operator""_test;
-        using GridFormat::Testing::expect;
-        using GridFormat::Testing::eq;
-
         "generic_reader_vti_interfaces"_test = [&] () {
             GridFormat::Reader vti_reader;
             vti_reader.open(generated_data_folder / vti_filename);

--- a/test/api/test_generic_reader.cpp
+++ b/test/api/test_generic_reader.cpp
@@ -286,15 +286,14 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
     using GridFormat::Testing::eq;
 
     "generic_reader_throws_on_non_matching_format"_test = [&] () {
-        GridFormat::Reader r{GridFormat::vtr};
-        r.open(vtr_filename);
+        GridFormat::Reader r{GridFormat::pvd_with(GridFormat::vtr)};
+        r.open(generated_data_folder / vtr_filename);
         GridFormat::Testing::expect(throws<GridFormat::IOError>([&] () { r.open(vti_filename); }));
     };
 
     // check that reader exposes image/rectilinear grid-specific interfaces
     if (!is_parallel) {
-        "generic_reader_vti_interfaces"_test = [&] () {
-            GridFormat::Reader vti_reader;
+        const auto _vti_test = [&] (auto& vti_reader) {
             vti_reader.open(generated_data_folder / vti_filename);
 
             expect(eq(vti_reader.extents()[0], std::size_t{4}));
@@ -318,8 +317,17 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
             expect(std::abs(vti_reader.spacing()[2] - 0.0) < 1e-6);
         };
 
-        "generic_reader_vtr_interfaces"_test = [&] () {
-            GridFormat::Reader vtr_reader;
+        "generic_reader_vti_interfaces_unbound"_test = [&] () {
+            GridFormat::Reader generic_reader;
+            _vti_test(generic_reader);
+        };
+
+        "generic_reader_vti_interfaces_bound"_test = [&] () {
+            GridFormat::Reader bound_reader{GridFormat::pvd_with(GridFormat::vti)};
+            _vti_test(bound_reader);
+        };
+
+        const auto _vtr_test = [&] (auto& vtr_reader) {
             vtr_reader.open(generated_data_folder / vtr_filename);
             for (unsigned int dir = 0; dir < 3; ++dir) {
                 const double spacing = std::array{1.0/4.0, 1.0/5.0, 0.0}[dir];
@@ -327,6 +335,16 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
                     return std::abs(x - spacing*static_cast<double>(i++)) < 1e-6;
                 }));
             }
+        };
+
+        "generic_reader_vtr_interfaces_unbound"_test = [&] () {
+            GridFormat::Reader generic_reader;
+            _vtr_test(generic_reader);
+        };
+
+        "generic_reader_vtr_interfaces_bound"_test = [&] () {
+            GridFormat::Reader bound_reader{GridFormat::pvd_with(GridFormat::vtr)};
+            _vtr_test(bound_reader);
         };
     }
 

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 gridformat_add_test(test_type_traits test_type_traits.cpp)
 gridformat_add_test(test_buffer_field test_buffer_field.cpp)
+gridformat_add_test(test_empty_field test_empty_field.cpp)
 gridformat_add_test(test_concepts test_concepts.cpp)
 gridformat_add_test(test_enumerated_range test_enumerated_range.cpp)
 gridformat_add_test(test_filtered_range test_filtered_range.cpp)

--- a/test/common/test_empty_field.cpp
+++ b/test/common/test_empty_field.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2022-2023 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>
+// SPDX-License-Identifier: MIT
+
+#include <vector>
+#include <algorithm>
+
+#include <gridformat/common/empty_field.hpp>
+
+#include "../testing.hpp"
+
+int main() {
+
+    using GridFormat::Testing::operator""_test;
+    using GridFormat::Testing::expect;
+    using GridFormat::Testing::throws;
+    using GridFormat::Testing::eq;
+
+    "empty_field_layout"_test = [&] () {
+        GridFormat::EmptyField field{GridFormat::float32};
+        expect(eq(field.layout().dimension(), std::size_t{0}));
+    };
+
+    "empty_field_precision"_test = [&] () {
+        GridFormat::EmptyField field{GridFormat::float32};
+        expect(field.precision() == GridFormat::DynamicPrecision{GridFormat::float32});
+    };
+
+    "empty_field_serialization"_test = [&] () {
+        GridFormat::EmptyField field{GridFormat::float32};
+        auto s = field.serialized();
+        expect(eq(s.size(), std::size_t{0}));
+    };
+
+    return 0;
+}

--- a/test/common/test_md_layout.cpp
+++ b/test/common/test_md_layout.cpp
@@ -10,6 +10,7 @@
 int main() {
     using GridFormat::Testing::operator""_test;
     using GridFormat::Testing::expect;
+    using GridFormat::Testing::throws;
     using GridFormat::Testing::eq;
 
     "md_layout"_test = [] () {
@@ -24,7 +25,7 @@ int main() {
     "md_layout_scalar"_test = [] () {
         const auto layout = GridFormat::get_md_layout(double{});
         expect(eq(layout.number_of_entries(), std::size_t{1}));
-        expect(eq(layout.dimension(), std::size_t{0}));
+        expect(eq(layout.dimension(), std::size_t{1}));
     };
 
     "md_layout_vector"_test = [] () {
@@ -52,6 +53,27 @@ int main() {
         std::ostringstream s;
         s << layout;
         expect(eq(s.str(), std::string{"(2,4)"}));
+    };
+
+    "md_layout_export"_test = [] () {
+        GridFormat::MDLayout layout{{4}};
+        std::array<std::size_t, 1> dims{0};
+        layout.export_to(dims);
+        expect(eq(dims.at(0), std::size_t{4}));
+    };
+
+    "md_layout_export_throws_on_too_small_range"_test = [] () {
+        GridFormat::MDLayout layout{{4, 1}};
+        std::array<std::size_t, 1> dims{0};
+        expect(throws<GridFormat::SizeError>([&] () { layout.export_to(dims); }));
+    };
+
+    "md_layout_sub_layout_fails_on_too_large_codim"_test = [] () {
+        std::vector<std::array<double, 4>> vector(2);
+        const auto layout = GridFormat::get_md_layout(vector);
+        expect(throws<GridFormat::ValueError>([&] () {
+            layout.sub_layout(2);
+        }));
     };
 
     return 0;

--- a/test/common/test_reserved_string.cpp
+++ b/test/common/test_reserved_string.cpp
@@ -80,5 +80,14 @@ int main() {
         expect(throws<GridFormat::ValueError>([&] () { GridFormat::ReservedString{data}; }));
     };
 
+    "reserved_string_eq_operator"_test = [] () {
+        GridFormat::ReservedString<10> a{"hello"};
+        GridFormat::ReservedString<10> b{"hello"};
+        GridFormat::ReservedString<10> c{"hell"};
+        expect(a == b);
+        expect(a != c);
+        expect(c != a);
+    };
+
     return 0;
 }

--- a/test/common/test_reserved_string.cpp
+++ b/test/common/test_reserved_string.cpp
@@ -75,5 +75,10 @@ int main() {
         expect(eq(std::string_view{str}, std::string_view{"hello"}));
     };
 
+    "reserved_string_ctor_throws_on_missing_null_terminator"_test = [] () {
+        char data[4] = {'a', 'b', 'c', 'd'};
+        expect(throws<GridFormat::ValueError>([&] () { GridFormat::ReservedString{data}; }));
+    };
+
     return 0;
 }

--- a/test/common/test_serialization.cpp
+++ b/test/common/test_serialization.cpp
@@ -13,6 +13,7 @@ int main() {
 
     using GridFormat::Testing::operator""_test;
     using GridFormat::Testing::expect;
+    using GridFormat::Testing::throws;
 
     "serialization_push_back"_test = [] () {
         GridFormat::Serialization s;
@@ -33,6 +34,12 @@ int main() {
         std::ranges::copy(std::vector{1, 2, 3, 4}, span.begin());
         s.cut_front(2*sizeof(int));
         expect(std::ranges::equal(s.template as_span_of<int>(), std::vector{3, 4}));
+    };
+
+    "serialization_cut_front_throws_on_exceeding_size"_test = [] () {
+        GridFormat::Serialization s;
+        s.resize(4);
+        expect(throws<GridFormat::SizeError>([&] () { s.cut_front(5); }));
     };
 
     return 0;

--- a/test/parallel/CMakeLists.txt
+++ b/test/parallel/CMakeLists.txt
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2022-2023 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>
+# SPDX-License-Identifier: MIT
+
+gridformat_add_test(test_null_communicator test_null_communicator.cpp)

--- a/test/parallel/test_null_communicator.cpp
+++ b/test/parallel/test_null_communicator.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2022-2023 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>
+// SPDX-License-Identifier: MIT
+
+#include <vector>
+#include <algorithm>
+#include <ranges>
+
+#include <gridformat/parallel/communication.hpp>
+#include "../testing.hpp"
+
+int main() {
+    using GridFormat::Testing::operator""_test;
+    using GridFormat::Testing::expect;
+    using GridFormat::Testing::eq;
+
+    const GridFormat::NullCommunicator comm{};
+    int some_value = 1;
+    "null_communicator_sum"_test = [&] () { expect(eq(GridFormat::Parallel::sum(comm, some_value), int{1})); };
+    "null_communicator_min"_test = [&] () { expect(eq(GridFormat::Parallel::min(comm, some_value), int{1})); };
+    "null_communicator_max"_test = [&] () { expect(eq(GridFormat::Parallel::max(comm, some_value), some_value)); };
+    "null_communicator_broadcast"_test = [&] () {
+        expect(eq(GridFormat::Parallel::broadcast(comm, some_value), some_value));
+    };
+    "null_communicator_gather"_test = [&] () {
+        expect(std::ranges::equal(
+            GridFormat::Parallel::gather(comm, some_value),
+            std::vector<int>{some_value}
+        ));
+    };
+    "null_communicator_gather_vec"_test = [&] () {
+        std::vector vals{some_value};
+        expect(std::ranges::equal(
+            GridFormat::Parallel::gather(comm, vals),
+            std::vector<int>{some_value}
+        ));
+    };
+    "null_communicator_gather_range"_test = [&] () {
+        expect(std::ranges::equal(
+            GridFormat::Parallel::gather(comm, std::vector{some_value} | std::views::all),
+            std::vector<int>{some_value}
+        ));
+    };
+
+    "null_communicator_scatter"_test = [&] () {
+        std::vector vals{some_value};
+        expect(std::ranges::equal(
+            GridFormat::Parallel::scatter(comm, vals),
+            std::vector<int>{some_value}
+        ));
+    };
+    "null_communicator_gather_vec"_test = [&] () {
+        std::vector vals{some_value};
+        expect(std::ranges::equal(
+            GridFormat::Parallel::gather(comm, vals | std::views::all),
+            std::vector<int>{some_value}
+        ));
+    };
+    "null_communicator_gather_array"_test = [&] () {
+        std::array<int, 1> vals{some_value};
+        expect(std::ranges::equal(
+            GridFormat::Parallel::gather(comm, vals),
+            std::vector<int>{some_value}
+        ));
+    };
+
+    return 0;
+}

--- a/test/vtk/CMakeLists.txt
+++ b/test/vtk/CMakeLists.txt
@@ -18,7 +18,7 @@ gridformat_add_regression_test(test_vtu_reader test_vtu_reader.cpp "reader_vtu_*
 target_compile_definitions(test_vtu_reader PRIVATE TEST_DATA_PATH="${CMAKE_CURRENT_LIST_DIR}/test_data")
 
 gridformat_add_parallel_regression_test(test_pvtu_writer test_pvtu_writer.cpp 2 "pvtu_*.pvtu")
-gridformat_add_parallel_regression_test(test_pvtu_reader test_pvtu_reader.cpp 2 "reader_pvtu_*.pvtu")
+gridformat_add_parallel_regression_test(test_pvtu_reader test_pvtu_reader.cpp 4 "reader_pvtu_*.pvtu")
 gridformat_add_parallel_regression_test(test_pvti_reader test_pvti_reader.cpp 2 "reader_pvti_*.pvti||reader_pvti_*.vtu")
 gridformat_add_parallel_regression_test(test_pvtr_reader test_pvtr_reader.cpp 2 "reader_pvtr_*.pvtr||reader_pvtr_*.vtu")
 gridformat_add_parallel_regression_test(test_pvts_reader test_pvts_reader.cpp 2 "reader_pvts_*.pvts||reader_pvts_*.vtu")

--- a/test/vtk/test_parallel_pvd_reader.cpp
+++ b/test/vtk/test_parallel_pvd_reader.cpp
@@ -78,7 +78,6 @@ std::string test_pvd(const std::string& acronym, const Communicator& comm) {
 
             expect(eq(GridFormat::number_of_cells(sequential_grid), GridFormat::number_of_cells(grid)*size));
             expect(eq(sequential_reader.number_of_cells(), GridFormat::number_of_cells(grid)*size));
-            expect(eq(sequential_reader.number_of_pieces(), std::size_t{1}));
 
             for (unsigned int step = 0; step < sequential_reader.number_of_steps(); ++step) {
                 sequential_reader.set_step(step);

--- a/test/vtk/test_pvti_reader.cpp
+++ b/test/vtk/test_pvti_reader.cpp
@@ -88,10 +88,6 @@ int main(int argc, char** argv) {
         GridFormat::PVTIReader sequential_reader{};
         sequential_reader.open(test_filename);
 
-        "sequential_pvti_read_number_of_pieces"_test = [&] () {
-            expect(eq(sequential_reader.number_of_pieces(), std::size_t{1}));
-        };
-
         "sequential_pvti_read_number_of_entities"_test = [&] () {
             expect(eq(sequential_reader.number_of_cells(), num_total_cells));
             expect(eq(sequential_reader.number_of_points(), num_total_points));

--- a/test/vtk/test_pvtp_reader.cpp
+++ b/test/vtk/test_pvtp_reader.cpp
@@ -63,10 +63,6 @@ int main(int argc, char** argv) {
         reader = GridFormat::PVTPReader{};
         reader.open(test_filename);
 
-        "sequential_pvtp_read_number_of_pieces"_test = [&] () {
-            expect(eq(reader.number_of_pieces(), std::size_t{1}));
-        };
-
         "sequential_pvtp_read_number_of_entities"_test = [&] () {
             expect(eq(reader.number_of_cells(), num_all_cells));
             expect(eq(reader.number_of_points(), num_all_points));

--- a/test/vtk/test_pvtr_reader.cpp
+++ b/test/vtk/test_pvtr_reader.cpp
@@ -89,10 +89,6 @@ int main(int argc, char** argv) {
         GridFormat::PVTRReader sequential_reader{};
         sequential_reader.open(test_filename);
 
-        "sequential_pvtr_read_number_of_pieces"_test = [&] () {
-            expect(eq(sequential_reader.number_of_pieces(), std::size_t{1}));
-        };
-
         "sequential_pvtr_read_number_of_entities"_test = [&] () {
             expect(eq(sequential_reader.number_of_cells(), num_total_cells));
             expect(eq(sequential_reader.number_of_points(), num_total_points));

--- a/test/vtk/test_pvts_reader.cpp
+++ b/test/vtk/test_pvts_reader.cpp
@@ -74,10 +74,6 @@ int main(int argc, char** argv) {
         GridFormat::PVTSReader sequential_reader{};
         sequential_reader.open(test_filename);
 
-        "sequential_pvts_read_number_of_pieces"_test = [&] () {
-            expect(eq(sequential_reader.number_of_pieces(), std::size_t{1}));
-        };
-
         "sequential_pvts_read_number_of_entities"_test = [&] () {
             expect(eq(sequential_reader.number_of_cells(), num_total_cells));
             expect(eq(sequential_reader.number_of_points(), num_total_points));

--- a/test/vtk/test_pvtu_reader.cpp
+++ b/test/vtk/test_pvtu_reader.cpp
@@ -21,51 +21,94 @@
 int main(int argc, char** argv) {
     MPI_Init(&argc, &argv);
 
-    const auto comm = MPI_COMM_WORLD;
-    const auto rank = GridFormat::Parallel::rank(comm);
-    const auto grid = GridFormat::Test::make_unstructured_2d(rank);
-    GridFormat::PVTUWriter writer{grid, comm};
-    GridFormat::PVTUReader reader{comm};
-    const auto test_filename = GridFormat::Test::test_reader<2, 2>(
-        writer,
-        reader,
-        "reader_pvtu_test_file_2d_in_2d",
-        {},
-        (rank == 0)
-    );
+    if (GridFormat::Parallel::size(MPI_COMM_WORLD) != 4)
+        throw std::runtime_error("This test requires to be run with four processes");
 
+    const auto root_rank = 0;
+    const auto world_comm = MPI_COMM_WORLD;
+    const auto world_rank = GridFormat::Parallel::rank(world_comm);
+    const auto my_write_color = world_rank < 3 ? int{0} : int{1};
+    const auto my_read_color = world_rank < 2 ? int{0} : int{1};
+    MPI_Comm write_comm;
+    MPI_Comm_split(world_comm, my_write_color, world_rank, &write_comm);
+    MPI_Comm read_comm;
+    MPI_Comm_split(world_comm, my_read_color, world_rank, &read_comm);
+
+    std::string test_filename = "";
+    std::size_t num_cells_per_rank = 0;
+    std::size_t num_points_per_rank = 0;
     std::vector<std::string> pfield_names;
     std::vector<std::string> cfield_names;
     std::vector<std::string> mfield_names;
-    std::ranges::copy(point_field_names(reader), std::back_inserter(pfield_names));
-    std::ranges::copy(cell_field_names(reader), std::back_inserter(cfield_names));
-    std::ranges::copy(meta_data_field_names(reader), std::back_inserter(mfield_names));
-
-    const auto num_cells = reader.number_of_cells();
-    const auto num_points = reader.number_of_points();
-    const auto num_all_cells = GridFormat::Parallel::broadcast(comm, GridFormat::Parallel::sum(comm, num_cells));
-    const auto num_all_points = GridFormat::Parallel::broadcast(comm, GridFormat::Parallel::sum(comm, num_points));
 
     using GridFormat::Testing::operator""_test;
     using GridFormat::Testing::expect;
     using GridFormat::Testing::eq;
 
-    "pvtu_reader_name"_test = [&] () {
-        expect(reader.name() == "PVTUReader");
-    };
+    // Write file with 3 processes
+    if (my_write_color == 0) {
+        std::cout << "Do write on rank " << world_rank << std::endl;
+        const auto grid = GridFormat::Test::make_unstructured_2d(world_rank);
+        num_cells_per_rank = GridFormat::number_of_cells(grid);
+        num_points_per_rank = GridFormat::number_of_points(grid);
+        GridFormat::PVTUWriter writer{grid, write_comm};
+        GridFormat::PVTUReader reader{write_comm};
+        test_filename = GridFormat::Test::test_reader<2, 2>(
+            writer,
+            reader,
+            "reader_pvtu_test_file_2d_in_2d",
+            {},
+            (world_rank == 0)
+        );
 
-    "parallel_pvtu_read_number_of_pieces"_test = [&] () {
-        expect(eq(reader.number_of_pieces(), static_cast<std::size_t>(GridFormat::Parallel::size(comm))));
+        std::ranges::copy(point_field_names(reader), std::back_inserter(pfield_names));
+        std::ranges::copy(cell_field_names(reader), std::back_inserter(cfield_names));
+        std::ranges::copy(meta_data_field_names(reader), std::back_inserter(mfield_names));
+
+        "pvtu_reader_name"_test = [&] () {
+            expect(reader.name() == "PVTUReader");
+        };
+
+        "parallel_pvtu_read_number_of_pieces"_test = [&] () {
+            expect(eq(reader.number_of_pieces(), static_cast<std::size_t>(GridFormat::Parallel::size(write_comm))));
+        };
+    }
+
+    // broadcast info on the written files/fields
+    const auto broadcast_string = [&] (const std::string& in) {
+        std::string result;
+        std::ranges::copy(
+            GridFormat::Parallel::broadcast(world_comm, in, root_rank),
+            std::back_inserter(result)
+        );
+        return result;
     };
+    test_filename = broadcast_string(test_filename);
+    num_cells_per_rank = GridFormat::Parallel::broadcast(world_comm, num_cells_per_rank, root_rank);
+    num_points_per_rank = GridFormat::Parallel::broadcast(world_comm, num_points_per_rank, root_rank);
+    pfield_names.resize(GridFormat::Parallel::broadcast(world_comm, cfield_names.size(), root_rank));
+    cfield_names.resize(GridFormat::Parallel::broadcast(world_comm, pfield_names.size(), root_rank));
+    mfield_names.resize(GridFormat::Parallel::broadcast(world_comm, mfield_names.size(), root_rank));
+    for (auto& field_name : cfield_names) field_name = broadcast_string(field_name);
+    for (auto& field_name : pfield_names) field_name = broadcast_string(field_name);
+    for (auto& field_name : mfield_names) field_name = broadcast_string(field_name);
+    std::cout << "Filename on rank " << world_rank << ": " << test_filename << std::endl;
+    std::cout << "Number of cells (per rank) on rank " << world_rank << ": " << num_cells_per_rank << std::endl;
+    std::cout << "Number of points (per rank) on rank " << world_rank << ": " << num_points_per_rank << std::endl;
+    std::cout << "Meta data fields on rank " << world_rank << ": " << GridFormat::as_string(mfield_names) << std::endl;
+    std::cout << "Point fields on rank " << world_rank << ": " << GridFormat::as_string(pfield_names) << std::endl;
+    std::cout << "Cell fields on rank " << world_rank << ": " << GridFormat::as_string(cfield_names) << std::endl;
+
 
     // test that sequential I/O yields the expected results
-    if (rank == 0) {
-        reader = GridFormat::PVTUReader{};
+    if (world_rank == 0) {
+        std::cout << "Reading '" << test_filename << "' sequentially on rank " << world_rank << std::endl;
+        GridFormat::PVTUReader reader{};
         reader.open(test_filename);
 
         "sequential_pvtu_read_number_of_entities"_test = [&] () {
-            expect(eq(reader.number_of_cells(), num_all_cells));
-            expect(eq(reader.number_of_points(), num_all_points));
+            expect(eq(reader.number_of_cells(), num_cells_per_rank*3));
+            expect(eq(reader.number_of_points(), num_points_per_rank*3));
         };
 
         "sequential_pvtu_read_field_names"_test = [&] () {
@@ -80,7 +123,13 @@ int main(int argc, char** argv) {
             return std::move(factory).grid();
         } ();
 
+        "sequential_pvtu_number_of_exported_entities"_test = [&] () {
+            expect(eq(GridFormat::number_of_cells(sequential_grid), num_cells_per_rank*3));
+            expect(eq(GridFormat::number_of_points(sequential_grid), num_points_per_rank*3));
+        };
+
         "sequential_pvtu_read_point_fields"_test = [&] () {
+            expect(GridFormat::Ranges::size(point_fields(reader)) > 0);
             for (const auto& [name, field_ptr] : point_fields(reader))
                 expect(GridFormat::Test::test_field_values<2>(
                     name, field_ptr, sequential_grid, GridFormat::points(sequential_grid)
@@ -88,11 +137,120 @@ int main(int argc, char** argv) {
         };
 
         "sequential_pvtu_read_cell_fields"_test = [&] () {
+            expect(GridFormat::Ranges::size(cell_fields(reader)) > 0);
             for (const auto& [name, field_ptr] : cell_fields(reader))
                 expect(GridFormat::Test::test_field_values<2>(
                     name, field_ptr, sequential_grid, GridFormat::cells(sequential_grid)
                 ));
         };
+    }
+
+    // test that when reading with more processes than pieces in the file, the last piece is empty
+    GridFormat::Parallel::barrier(world_comm);
+    {
+        std::cout << "Reading '" << test_filename << "' on all 4 processes; rank = " << world_rank << std::endl;
+        GridFormat::PVTUReader reader{world_comm};
+        reader.open(test_filename);
+        const auto proc_grid = [&] () {
+            GridFormat::Test::UnstructuredGridFactory<2, 2> factory;
+            reader.export_grid(factory);
+            return std::move(factory).grid();
+        } ();
+
+        if (world_rank < 3) {
+            "parallel_pvtu_more_procs_num_cells_on_non_empty_piece"_test = [&] () {
+                expect(eq(reader.number_of_cells(), num_cells_per_rank));
+                expect(eq(reader.number_of_points(), num_points_per_rank));
+            };
+
+            "parallel_pvtu_more_procs_point_fields_on_non_empty_piece"_test = [&] () {
+                expect(GridFormat::Ranges::size(point_fields(reader)) > 0);
+                for (const auto& [name, field_ptr] : point_fields(reader))
+                    expect(GridFormat::Test::test_field_values<2>(
+                        name, field_ptr, proc_grid, GridFormat::points(proc_grid)
+                    ));
+            };
+
+            "parallel_pvtu_more_procs_cell_fields_on_non_empty_piece"_test = [&] () {
+                expect(GridFormat::Ranges::size(cell_fields(reader)) > 0);
+                for (const auto& [name, field_ptr] : cell_fields(reader))
+                    expect(GridFormat::Test::test_field_values<2>(
+                        name, field_ptr, proc_grid, GridFormat::cells(proc_grid)
+                    ));
+            };
+        } else {
+            "parallel_pvtu_more_procs_num_cells_on_empty_piece"_test = [&] () {
+                expect(eq(reader.number_of_cells(), std::size_t{0}));
+                expect(eq(reader.number_of_points(), std::size_t{0}));
+                expect(eq(GridFormat::number_of_cells(proc_grid), std::size_t{0}));
+                expect(eq(GridFormat::number_of_points(proc_grid), std::size_t{0}));
+            };
+        }
+    }
+
+    // test that exceeding pieces can be merged when reading with less ranks
+    GridFormat::Parallel::barrier(world_comm);
+    if (my_read_color == 0) {
+        std::cout << "Reading '" << test_filename << "' on only 2 processes (with merging); rank = " << world_rank << std::endl;
+        GridFormat::PVTUReader reader{read_comm, true};
+        reader.open(test_filename);
+        const auto proc_grid = [&] () {
+            GridFormat::Test::UnstructuredGridFactory<2, 2> factory;
+            reader.export_grid(factory);
+            return std::move(factory).grid();
+        } ();
+
+        if (world_rank == 0) {
+            "parallel_pvtu_less_procs_num_cells_on_normal_piece"_test = [&] () {
+                expect(eq(reader.number_of_cells(), num_cells_per_rank));
+                expect(eq(reader.number_of_points(), num_points_per_rank));
+                expect(eq(GridFormat::number_of_cells(proc_grid), num_cells_per_rank));
+                expect(eq(GridFormat::number_of_points(proc_grid), num_points_per_rank));
+            };
+
+            "parallel_pvtu_less_procs_point_fields_on_normal_piece"_test = [&] () {
+                expect(GridFormat::Ranges::size(point_fields(reader)) > 0);
+                for (const auto& [name, field_ptr] : point_fields(reader))
+                    expect(GridFormat::Test::test_field_values<2>(
+                        name, field_ptr, proc_grid, GridFormat::points(proc_grid)
+                    ));
+            };
+
+            "parallel_pvtu_less_procs_cell_fields_on_normal_piece"_test = [&] () {
+                expect(GridFormat::Ranges::size(cell_fields(reader)) > 0);
+                for (const auto& [name, field_ptr] : cell_fields(reader))
+                    expect(GridFormat::Test::test_field_values<2>(
+                        name, field_ptr, proc_grid, GridFormat::cells(proc_grid)
+                    ));
+            };
+        } else {
+            "parallel_pvtu_less_procs_num_cells_on_merged_piece"_test = [&] () {
+                expect(eq(reader.number_of_cells(), num_cells_per_rank*2));
+                expect(eq(reader.number_of_points(), num_points_per_rank*2));
+                expect(eq(GridFormat::number_of_cells(proc_grid), num_cells_per_rank*2));
+                expect(eq(GridFormat::number_of_points(proc_grid), num_points_per_rank*2));
+            };
+
+            "parallel_pvtu_less_procs_point_fields_on_merged_piece"_test = [&] () {
+                expect(GridFormat::Ranges::size(point_fields(reader)) > 0);
+                for (const auto& [name, field_ptr] : point_fields(reader)) {
+                    expect(eq(field_ptr->layout().extent(0), num_points_per_rank*2));
+                    expect(GridFormat::Test::test_field_values<2>(
+                        name, field_ptr, proc_grid, GridFormat::points(proc_grid)
+                    ));
+                }
+            };
+
+            "parallel_pvtu_less_procs_cell_fields_on_merged_piece"_test = [&] () {
+                expect(GridFormat::Ranges::size(cell_fields(reader)) > 0);
+                for (const auto& [name, field_ptr] : cell_fields(reader)) {
+                    expect(eq(field_ptr->layout().extent(0), num_cells_per_rank*2));
+                    expect(GridFormat::Test::test_field_values<2>(
+                        name, field_ptr, proc_grid, GridFormat::cells(proc_grid)
+                    ));
+                }
+            };
+        }
     }
 
     MPI_Finalize();

--- a/test/vtk/test_pvtu_reader.cpp
+++ b/test/vtk/test_pvtu_reader.cpp
@@ -63,10 +63,6 @@ int main(int argc, char** argv) {
         reader = GridFormat::PVTUReader{};
         reader.open(test_filename);
 
-        "sequential_pvtu_read_number_of_pieces"_test = [&] () {
-            expect(eq(reader.number_of_pieces(), std::size_t{1}));
-        };
-
         "sequential_pvtu_read_number_of_entities"_test = [&] () {
             expect(eq(reader.number_of_cells(), num_all_cells));
             expect(eq(reader.number_of_points(), num_all_points));

--- a/test/vtk/test_vtk_hdf_parallel_unstructured_grid_reader.cpp
+++ b/test/vtk/test_vtk_hdf_parallel_unstructured_grid_reader.cpp
@@ -16,9 +16,75 @@
 #include "../testing.hpp"
 
 
+template<typename Reader, typename Grid>
+void test_sequentially_opened(const Reader& reader,
+                              const Grid& piece_grid,
+                              const std::size_t num_pieces,
+                              double time_step = 1.0) {
+    using GridFormat::Testing::expect;
+    using GridFormat::Testing::eq;
+
+    const auto read_grid = [&] () {
+        GridFormat::Test::UnstructuredGridFactory<2, 2> factory;
+        reader.export_grid(factory);
+        return std::move(factory).grid();
+    } ();
+    const std::size_t num_expected_cells = GridFormat::number_of_cells(piece_grid)*num_pieces;
+    const std::size_t num_expected_points = GridFormat::number_of_points(piece_grid)*num_pieces;
+    std::size_t cell_count = 0;
+    reader.visit_cells([&] (const auto&, const auto&) { cell_count++; });
+
+    expect(eq(cell_count, num_expected_cells));
+    expect(eq(reader.number_of_cells(), num_expected_cells));
+    expect(eq(reader.number_of_points(), num_expected_points));
+    expect(eq(GridFormat::number_of_cells(read_grid), num_expected_cells));
+    expect(eq(GridFormat::number_of_points(read_grid), num_expected_points));
+
+    for (const auto& [name, field_ptr] : cell_fields(reader)) {
+        expect(field_ptr->layout().dimension() > 0);
+        expect(eq(field_ptr->layout().extent(0), num_expected_cells));
+        expect(GridFormat::Test::test_field_values<2>(
+            name, field_ptr, read_grid, GridFormat::cells(read_grid), time_step
+        ));
+    }
+
+    for (const auto& [name, field_ptr] : point_fields(reader)) {
+        expect(field_ptr->layout().dimension() > 0);
+        expect(eq(field_ptr->layout().extent(0), num_expected_points));
+        expect(GridFormat::Test::test_field_values<2>(
+            name, field_ptr, read_grid, GridFormat::points(read_grid), time_step
+        ));
+    }
+}
+
+
+template<typename Grid>
+void test_sequential_io(const Grid& piece_grid,
+                        const std::size_t num_pieces,
+                        const std::string& filename,
+                        double time_step = 1.0) {
+    GridFormat::VTKHDFReader reader;
+    reader.open(filename);
+    test_sequentially_opened(reader, piece_grid, num_pieces, time_step);
+}
+
+template<typename Grid>
+void test_sequential_time_series_io(const Grid& piece_grid,
+                                 const std::size_t num_pieces,
+                                 const std::string& filename) {
+    GridFormat::VTKHDFReader reader;
+    reader.open(filename);
+    for (std::size_t step = 0; step < reader.number_of_steps(); ++step) {
+        reader.set_step(step);
+        test_sequentially_opened(reader, piece_grid, num_pieces, reader.time_at_step(step));
+    }
+}
+
+
 int main(int argc, char** argv) {
     MPI_Init(&argc, &argv);
 
+    const auto num_ranks = GridFormat::Parallel::size(MPI_COMM_WORLD);
     const auto rank = GridFormat::Parallel::rank(MPI_COMM_WORLD);
     const auto grid = GridFormat::Test::make_unstructured_2d(rank);
     const bool verbose = (rank == 0);
@@ -27,38 +93,45 @@ int main(int argc, char** argv) {
     using GridFormat::Testing::expect;
     using GridFormat::Testing::eq;
 
-
     {
         GridFormat::VTKHDFUnstructuredGridWriter writer{grid, MPI_COMM_WORLD};
 
-        {
+        const auto parallel_file = [&] () {
             GridFormat::VTKHDFUnstructuredGridReader reader{MPI_COMM_WORLD};
-            test_reader<2, 2>(writer, reader, "reader_vtk_hdf_parallel_unstructured_test_file_2d_in_2d", {}, verbose);
+            const auto fn = test_reader<2, 2>(writer, reader, "reader_vtk_hdf_parallel_unstructured_test_file_2d_in_2d", {}, verbose);
             "parallel_vtk_hdf_unstructured_grid_reader_num_pieces"_test = [&] () {
-                expect(eq(reader.number_of_pieces(), static_cast<std::size_t>(GridFormat::Parallel::size(MPI_COMM_WORLD))));
+                expect(eq(reader.number_of_pieces(), static_cast<std::size_t>(num_ranks)));
             };
-        }
+            return fn;
+        } ();
         {  // test also convenience reader
             GridFormat::VTKHDFReader reader{MPI_COMM_WORLD};
             test_reader<2, 2>(writer, reader, "reader_vtk_hdf_parallel_unstructured_test_file_2d_in_2d_from_generic", {}, verbose);
             "parallel_vtk_hdf_reader_num_pieces"_test = [&] () {
-                expect(eq(reader.number_of_pieces(), static_cast<std::size_t>(GridFormat::Parallel::size(MPI_COMM_WORLD))));
+                expect(eq(reader.number_of_pieces(), static_cast<std::size_t>(num_ranks)));
             };
         }
+        if (rank == 0)  // test also sequential I/O of parallel file
+            "parallel_vtk_hdf_reader_sequential_io"_test = [&] () {
+                std::cout << "Testing sequential I/O with " << parallel_file << std::endl;
+                test_sequential_io(grid, num_ranks, parallel_file);
+            };
+        GridFormat::Parallel::barrier(MPI_COMM_WORLD);
     }
     {
-        {
+        const auto parallel_file = [&] () {
             GridFormat::VTKHDFUnstructuredTimeSeriesWriter writer{
                 grid, MPI_COMM_WORLD, "reader_vtk_hdf_parallel_unstructured_time_series_2d_in_2d"
             };
             GridFormat::VTKHDFUnstructuredGridReader reader{MPI_COMM_WORLD};
-            test_reader<2, 2>(writer, reader, [&] (const auto& grid, const auto& filename) {
+            const auto fn = test_reader<2, 2>(writer, reader, [&] (const auto& grid, const auto& filename) {
                 return GridFormat::VTKHDFUnstructuredTimeSeriesWriter{grid, MPI_COMM_WORLD, filename};
             }, {}, verbose);
             "parallel_vtk_hdf_unstructured_grid_time_series_reader_num_pieces"_test = [&] () {
-                expect(eq(reader.number_of_pieces(), static_cast<std::size_t>(GridFormat::Parallel::size(MPI_COMM_WORLD))));
+                expect(eq(reader.number_of_pieces(), static_cast<std::size_t>(num_ranks)));
             };
-        }
+            return fn;
+        } ();
         {  // test also convenience reader
             GridFormat::VTKHDFUnstructuredTimeSeriesWriter writer{
                 grid, MPI_COMM_WORLD, "reader_vtk_hdf_parallel_unstructured_time_series_2d_in_2d_from_generic"
@@ -68,9 +141,15 @@ int main(int argc, char** argv) {
                 return GridFormat::VTKHDFUnstructuredTimeSeriesWriter{grid, MPI_COMM_WORLD, filename};
             }, {}, verbose);
             "parallel_vtk_hdf_time_series_reader_num_pieces"_test = [&] () {
-                expect(eq(reader.number_of_pieces(), static_cast<std::size_t>(GridFormat::Parallel::size(MPI_COMM_WORLD))));
+                expect(eq(reader.number_of_pieces(), static_cast<std::size_t>(num_ranks)));
             };
         }
+        if (rank == 0)  // test also sequential I/O of parallel file
+            "parallel_vtk_hdf_reader_sequential_time_series_io"_test = [&] () {
+                std::cout << "Testing sequential time series I/O with " << parallel_file << std::endl;
+                test_sequential_time_series_io(grid, num_ranks, parallel_file);
+            };
+        GridFormat::Parallel::barrier(MPI_COMM_WORLD);
     }
 
     MPI_Finalize();


### PR DESCRIPTION
- introduces more options to converter cli tool
- fixes the `VTKHDFUnstructuredGridReader`, in particular for time series and in parallel
- fixes `MPI_Broadcast` and `MPI_Scatter` on dynamic ranges in case some processors don't have the ranges already resized
- fixes exporting grids from a reader when number_of_points = 0
- fixes unstructured pxml readers when merge_exceeding_pieces = true and number of processes < number of pieces
- (although unrelated) adds missing unit tests (see some of the commits prefixed with [test])

Fixes #205 