### PR TITLE
bump version to v0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         tar -cf ${HTML_DOC_FOLDER_NAME}.tar ${HTML_DOC_FOLDER_NAME}
     - uses: ncipollo/release-action@v1
       with:
-        artifacts: build/${HTML_DOC_FOLDER_NAME}.tar
-        bodyFile: ${DESCRIPTION_FILE}
+        artifacts: build/${{ env.HTML_DOC_FOLDER_NAME }}.tar
+        bodyFile: ${{ env.DESCRIPTION_FILE }}
         discussionCategory: "Show and tell"
         name: GridFormat ${{ github.ref_name }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,5 +29,5 @@ keywords:
   - grid file I/O
   - mesh file I/O
 license: MIT
-version: 0.1.0
-date-released: '2023-10-11'
+version: 0.1.1
+date-released: '2023-10-12'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ else()
   set(GRIDFORMAT_SUBPROJECT ON)
 endif()
 
-project(gridformat VERSION 0.1.0)
+project(gridformat VERSION 0.1.1)
 set(GRIDFORMAT_NAMESPACE "gridformat")
 
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -234,13 +234,13 @@ git push origin v1.2.3
 
 Afterwards, a release workflow will be triggered. If this runs through successfully, a release has been created. If not, the new tag
 has to be deleted and the procedure has to be repeated after fixing the errors. After a successful release, the version on `main`
-should be increased (with a suffix `-git`). Following the above example, you may run the following commands:
+should be increased (without triggering an actual release). Following the above example, you may run the following commands:
 
 ```bash
 git switch main
 git switch --create feature/bump-version
-python3 util/update_versions.py -v 1.2.4-git --skip-tag # only modifies versions, no commit or tag
-git commit -m "bump version to v1.2.3" .
+python3 util/update_versions.py -v 1.2.4 --skip-tag # only modifies versions, no commit or tag
+git commit -m "bump version to v1.2.4" .
 git push origin feature/bump-version
 ```
 


### PR DESCRIPTION
@timokoch, this bumps the version on main (0.1.0 release currently running). I removed the `-git` suffix thing because cmake actually fails configuring when set as version. But I don't want to introduce extra rules for cmake but have all versions consistent.