### PR TITLE
bump version to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 <!--SPDX-FileCopyrightText: 2023 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>-->
 <!--SPDX-License-Identifier: MIT-->
 
+
+# `GridFormat` 0.1.1
+
+## Fixes
+
+- Fixed the artifact path in the release workflow.
+
 # `GridFormat` 0.1.0
 
 Our very first release 🎉

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <!--SPDX-FileCopyrightText: 2023 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>-->
 <!--SPDX-License-Identifier: MIT-->
 
+# `GridFormat` 0.1.2
+
+## Fixes
+
+- Fixed description extraction from changelog for releases.
 
 # `GridFormat` 0.1.1
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,5 +29,5 @@ keywords:
   - grid file I/O
   - mesh file I/O
 license: MIT
-version: 0.1.1
-date-released: '2023-10-12'
+version: 0.1.2
+date-released: '2023-10-13'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ else()
   set(GRIDFORMAT_SUBPROJECT ON)
 endif()
 
-project(gridformat VERSION 0.1.1)
+project(gridformat VERSION 0.1.2)
 set(GRIDFORMAT_NAMESPACE "gridformat")
 
 include(GNUInstallDirs)

--- a/util/write_release_description.py
+++ b/util/write_release_description.py
@@ -12,7 +12,9 @@ CHANGELOG_VERSION_HEADER_PREFIX = "# `GridFormat` "
 def _get_changelog_content_for(version: str) -> str:
     with open(join(dirname(abspath(__file__)), "../CHANGELOG.md")) as changelog:
         _, content = changelog.read().split(f"{CHANGELOG_VERSION_HEADER_PREFIX}{version}", maxsplit=1)
-        return content.split("{CHANGELOG_VERSION_HEADER_PREFIX}")[0].strip("\n")
+        # strip rest of the header line
+        _, content = content.split("\n", maxsplit=1)
+        return content.split(f"{CHANGELOG_VERSION_HEADER_PREFIX}")[0].strip("\n")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Zenodo was down when releasing v0.1.1, so the webhook failed. Just triggered a new release. If that goes well, including the zenodo release, we should bump the version on main to v0.1.2.