### PR TITLE
Feature/ci test selection

### DIFF
--- a/.github/actions/set-git-variables/action.yml
+++ b/.github/actions/set-git-variables/action.yml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024 Dennis Gläser <dennis.a.glaeser@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: set-git-variables
+runs:
+  using: composite
+  steps:
+    - name: set-git-variables
+      run: |
+        if [[ ${{ github.event_name }} == "pull_request" ]]; then
+          echo "GFMT_ORIGIN=${{ github.event.pull_request.head.repo.clone_url }}" >> "$GITHUB_ENV"
+          echo "GFMT_TREE=${{ github.head_ref }}" >> "$GITHUB_ENV"
+          echo "GFMT_SOURCE_TREE=origin/${{ github.head_ref }}" >> "$GITHUB_ENV"
+        else
+          echo "GFMT_ORIGIN=${{ github.event.repository.clone_url }}" >> "$GITHUB_ENV"
+          echo "GFMT_TREE=${{ github.head_ref }}" >> "$GITHUB_ENV"
+          if [[ -z "$GFMT_TREE" ]]; then
+            echo "GFMT_TREE=${{ github.sha }}" >> "$GITHUB_ENV"
+          fi
+          echo "GFMT_SOURCE_TREE=${GFMT_TREE}" >> "$GITHUB_ENV"
+        fi
+      shell: bash

--- a/.github/actions/set-test-commands/action.yml
+++ b/.github/actions/set-test-commands/action.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2024 Dennis Gläser <dennis.a.glaeser@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: set-test-commands
+inputs:
+  source_tree:
+    required: True
+  target_tree:
+    required: True
+  build_directory:
+    required: True
+runs:
+  using: composite
+  steps:
+    - name: set-test-commands
+      run: |
+        if [[ ${{ github.ref_name }} == "main" ]]; then
+          echo "Using 'all' target on main branch (i.e. all tests are built & run)"
+          echo "all" > _affected_tests.txt
+        else
+          pushd ${{inputs.build_directory}}
+            echo "Detecting files that change from '${{inputs.source_tree}}' to '${{inputs.target_tree}}'"
+            python3 ../bin/detect_modified_files.py -s "${{inputs.source_tree}}" -t "${{inputs.target_tree}}" &> _modfiles.out
+
+            echo "Detecting tests affected by these changes"
+            python3 ../bin/detect_affected_tests.py -i _modfiles.out -o ../_affected_tests.txt
+          popd
+
+          BUILD_CMD=$(python3 bin/print_test_commands.py --build -f _affected_tests.txt)
+          echo "Setting build command to ${BUILD_CMD}"
+          echo "GFMT_BUILD_CMD=$BUILD_CMD" >> "$GITHUB_ENV"
+
+          TEST_CMD=$(python3 bin/print_test_commands.py --test -f _affected_tests.txt --ctest-args='--output-on-failure')
+          echo "Setting test command to ${TEST_CMD}"
+          echo "GFMT_TEST_CMD=$TEST_CMD" >> "$GITHUB_ENV"
+        fi
+      shell: bash

--- a/.github/actions/set-test-commands/action.yml
+++ b/.github/actions/set-test-commands/action.yml
@@ -33,5 +33,9 @@ runs:
           TEST_CMD=$(python3 bin/print_test_commands.py --test -f _affected_tests.txt --ctest-args='--output-on-failure')
           echo "Setting test command to ${TEST_CMD}"
           echo "GFMT_TEST_CMD=$TEST_CMD" >> "$GITHUB_ENV"
+
+          MEMCHECK_CMD=$(python3 bin/print_test_commands.py --build -f _affected_tests.txt --memcheck)
+          echo "Setting memcheck command to ${MEMCHECK_CMD}"
+          echo "GFMT_MEMCHECK_CMD=$MEMCHECK_CMD" >> "$GITHUB_ENV"
         fi
       shell: bash

--- a/.github/actions/test-installed-pkg/action.yml
+++ b/.github/actions/test-installed-pkg/action.yml
@@ -27,6 +27,16 @@ runs:
         cmake --install build
       shell: bash
 
+    - name: set-git-variables
+      uses: ./.github/actions/set-git-variables
+
+    - name: set-test-commands
+      uses: ./.github/actions/set-test-commands
+      with:
+        build_directory: build
+        source_tree: ${{ env.GFMT_SOURCE_TREE }}
+        target_tree: main
+
     - name: test-readme-cli-snippets
       run: |
         export PATH=$PATH:$(pwd)/install/bin
@@ -49,11 +59,12 @@ runs:
                 -DCMAKE_PREFIX_PATH=/gfmt-dependencies \
                 -DCMAKE_BUILD_TYPE=Release \
                 -B build
-          if [[ ${{ github.ref_name }} != "main" ]]; then
-            echo "Regression-testing sample files only for branch ${{ github.ref_name }}"
-            export GRIDFORMAT_REGRESSION_SAMPLES_ONLY=true
-          fi
-          pushd build && make build_tests && ctest --output-on-failure && popd
+          pushd build
+            echo "Invoking build command"
+            $(echo "$GFMT_BUILD_CMD")
+            echo "Invoking test command"
+            $(echo "$GFMT_TEST_CMD")
+          popd
       shell: bash
 
     - name: test-examples
@@ -69,15 +80,6 @@ runs:
 
     - name: test-examples-with-fetch-content
       run: |
-        if [[ ${{ github.event_name }} == "pull_request" ]]; then
-          GFMT_ORIGIN=${{ github.event.pull_request.head.repo.clone_url }}
-          GFMT_TREE=${{ github.head_ref }}
-        else
-          GFMT_TREE=$GITHUB_HEAD_REF
-          if [[ -z "$GFMT_TREE" ]]; then
-            GFMT_TREE=$GITHUB_SHA
-          fi
-        fi
         rm -rf examples/build && pushd examples
           cmake -DCMAKE_C_COMPILER=${{inputs.c_compiler}} \
                 -DCMAKE_CXX_COMPILER=${{inputs.cxx_compiler}} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           submodules: true
 
-      - name: run-valgrind
+      - name: configure
         run: |
           rm -rf build
           cmake -DCMAKE_C_COMPILER=/usr/bin/$DEFAULT_C_COMPILER \
@@ -130,7 +130,19 @@ jobs:
                 -DCMAKE_PREFIX_PATH=/gfmt-dependencies \
                 -DGRIDFORMAT_BUILD_TESTS=ON \
                 -B build
-          cd build && make memcheck
+
+      - name: set-git-variables
+        uses: ./.github/actions/set-git-variables
+
+      - name: set-test-commands
+        uses: ./.github/actions/set-test-commands
+        with:
+          build_directory: build
+          source_tree: ${{ env.GFMT_SOURCE_TREE }}
+          target_tree: main
+
+      - name: run-memcheck
+        run: cd build && $(echo "$GFMT_MEMCHECK_CMD")
 
 
   test-full-installation:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,18 +66,18 @@ jobs:
                 -DGRIDFORMAT_BUILD_TESTS=ON \
                 -B build | tee gfmt_cmake_log.txt
 
+      - name: set-git-variables
+        uses: ./.github/actions/set-git-variables
+
+      - name: set-test-commands
+        uses: ./.github/actions/set-test-commands
+        with:
+          build_directory: build
+          source_tree: ${{ env.GFMT_SOURCE_TREE }}
+          target_tree: main
+
       - name: check-documentation-code
         run: |
-          if [[ ${{ github.event_name }} == "pull_request" ]]; then
-            GFMT_ORIGIN=${{ github.event.pull_request.head.repo.clone_url }}
-            GFMT_TREE=${{ github.head_ref }}
-          else
-            GFMT_ORIGIN=${{ github.event.repository.clone_url }}
-            GFMT_TREE=$GITHUB_HEAD_REF
-            if [[ -z "$GFMT_TREE" ]]; then
-              GFMT_TREE=$GITHUB_SHA
-            fi
-          fi
           python3 test/test_readme_quick_start.py \
             -r $GFMT_TREE \
             -e "-DCMAKE_C_COMPILER=/usr/bin/gcc-12 -DCMAKE_CXX_COMPILER=/usr/bin/g++-12" \
@@ -89,7 +89,7 @@ jobs:
         run: cmake --build build
 
       - name: build-tests
-        run: pushd build && make build_tests && popd
+        run: pushd build && $(echo "$GFMT_BUILD_CMD") && popd
         shell: bash
 
       - name: test
@@ -98,7 +98,7 @@ jobs:
             echo "Regression-testing sample files only for branch ${{ github.ref_name }}"
             export GRIDFORMAT_REGRESSION_SAMPLES_ONLY=true
           fi
-          pushd build && ctest --output-on-failure && popd
+          pushd build && $(echo "$GFMT_TEST_CMD") && popd
         shell: bash
 
       - name: verify-no-skipped-tests

--- a/bin/detect_affected_tests.py
+++ b/bin/detect_affected_tests.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2024 Dennis Gläser <dennis.a.glaeser@gmail.com>
+# SPDX-License-Identifier: MIT
+
+"""
+Can be called from the build directory to find out which tests are affected by changes to files
+Note: this assumes that the targets and test names are identical. In case we change this one day,
+      this script should fail such that we detect the issue in the CI.
+"""
+
+import subprocess
+import argparse
+import json
+
+from os import getcwd
+from os.path import abspath, join, exists
+
+try:
+    import colorama
+    colorama.init()
+
+    def in_green(text: str) -> str:
+        return colorama.Fore.GREEN + text + colorama.Style.RESET_ALL
+
+    def in_red(text: str) -> str:
+        return colorama.Fore.RED + text + colorama.Style.RESET_ALL
+
+except ImportError:
+    def in_green(text: str) -> str:
+        return text
+
+    def in_red(text: str) -> str:
+        return text
+
+
+_TOP_DIR = abspath(join(getcwd(), ".."))
+
+
+def is_build_dir() -> bool:
+    return exists(join(getcwd(), "CMakeCache.txt"))
+
+
+def find_all_test_names() -> list[str]:
+    output = json.loads(
+        subprocess.run(["ctest", "--show-only=json-v1"], check=True, capture_output=True, text=True).stdout
+    )
+    return [data["name"] for data in output["tests"]]
+
+
+def get_build_command(test_name: str) -> str:
+    output = subprocess.run(["make", "--dry-run", test_name], check=True, capture_output=True, text=True).stdout
+    for line in output.split("\n"):
+        if line.startswith("cd ") and line.endswith(".cpp"):
+            return line
+    raise RuntimeError(f"Could not find build command for {test_name}")
+
+
+def get_included_headers(test_name: str, verbosity: int = 0, line_prefix: str = "", test_prefix: str = "") -> list[str]:
+    if verbosity > 1:
+        print(test_prefix)
+        print(f"{line_prefix}Finding headers for test {test_name}")
+    build_command = get_build_command(test_name)
+    folder_cmd, compile_command = build_command.split("&&", maxsplit=1)
+    build_dir = folder_cmd.split("cd ", maxsplit=1)[1].strip()
+    compiler, compiler_args = compile_command.strip().split(" ", maxsplit=1)
+    assert compiler.rsplit("-", maxsplit=1)[0].endswith("++")
+    composed_cmd = f"{compiler} {compiler_args} -MM -H".split(" ")
+    output = subprocess.run(composed_cmd, check=True, capture_output=True, text=True, cwd=build_dir).stderr
+    headers = [line.strip(" .") for line in output.split("\n") if line.startswith(".")]
+    headers = list(filter(lambda h: _TOP_DIR in h, headers))
+    if verbosity > 1:
+        print("\n".join(f"{line_prefix} - {h}" for h in headers))
+    return headers
+
+
+def is_affected(test_name: str, modified_files: set, verbosity: int = 0) -> bool:
+    if verbosity > 0:
+        print(f"Checking if {test_name} is affected ... ", end="")
+    headers = set(get_included_headers(test_name, verbosity, test_prefix="\n", line_prefix="\t"))
+    affected = len(modified_files.intersection(headers)) > 0
+    if verbosity > 0:
+        print(in_red("YES") if affected else in_green("NO"))
+    return affected
+
+
+def read_modified_files(input_file: str, verbosity: int = 0) -> set[str]:
+    modified_files = set(join(_TOP_DIR, p) for p in open(input_file).read().split("\n"))
+    if verbosity > 0:
+        print("Modified files:")
+        print("\n".join(f" - {f}" for f in modified_files))
+    return modified_files
+
+
+def has_cmake_file(modified_files: set[str]) -> bool:
+    def _is_cmake_file(path: str) -> bool:
+        return path.endswith("CMakeLists.txt")
+    return any(_is_cmake_file(p) for p in modified_files)
+
+
+def find_affected_tests(modified_files: set[str], verbosity: int = 0) -> list[str]:
+    result = [
+        test_name
+        for test_name in find_all_test_names()
+        if is_affected(test_name, modified_files, verbosity=verbosity)
+    ]
+
+    if verbosity > 0:
+        if result:
+            print("Affected tests:")
+            print("\n".join(f" - {t}" for t in result))
+        else:
+            print("No affected tests")
+
+    return result
+
+
+def write_output_file(affected_tests: list[str], out_file: str) -> None:
+    with open(out_file, "w") as output_file:
+        output_file.write("\n".join(affected_tests))
+
+
+if not is_build_dir():
+    raise RuntimeError("This script must be called from the top level of the build directory")
+
+parser = argparse.ArgumentParser(description="Find tests affected by modified headers")
+parser.add_argument("-i", "--input-file", required=True, help="file with a list of modified files separated by lines")
+parser.add_argument("-o", "--out-file", required=True, help="file to which to write the names of affected tests")
+parser.add_argument("-v", "--verbosity", required=False, default=1)
+args = vars(parser.parse_args())
+
+verbosity = int(args["verbosity"])
+modified_files = read_modified_files(args["input_file"])
+if has_cmake_file(modified_files):
+    if verbosity > 0:
+        print("Writing 'all' target because of modified cmake file(s)")
+    write_output_file(["all"], args["out_file"])
+else:
+    subprocess.run(["make", "clean"], check=True)
+    affected_tests = find_affected_tests(modified_files, verbosity)
+    write_output_file(affected_tests, args["out_file"])
+    subprocess.run(["make", "clean"], check=True)

--- a/bin/detect_modified_files.py
+++ b/bin/detect_modified_files.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2024 Dennis Gläser <dennis.a.glaeser@gmail.com>
+# SPDX-License-Identifier: MIT
+
+"""
+Prints all files that have been modified between two commits.
+"""
+
+import subprocess
+import argparse
+import os
+
+
+def prepare_repo() -> str:
+    _folder_name = "_tmpgfmt"
+    subprocess.run(["git", "clone", "https://github.com/dglaeser/gridformat", _folder_name], check=True, capture_output=True)
+    subprocess.run(["git", "fetch", "origin"], check=True, capture_output=True, cwd=_folder_name)
+    return _folder_name
+
+
+def get_modified_files(source_tree: str, target_tree: str) -> list[str]:
+    return subprocess.run(
+        ["git", "diff", "--name-only", source_tree, target_tree],
+        check=True, capture_output=True, text=True
+    ).stdout.strip(" \n").split("\n")
+
+
+def try_in(folder: str, action):
+    cwd = os.getcwd()
+    try:
+        os.chdir(folder)
+        result = action()
+    except Exception as e:
+        os.chdir(cwd)
+        raise e
+    os.chdir(cwd)
+    return result
+
+
+parser = argparse.ArgumentParser(description="Print the files that have been modified between two commits")
+parser.add_argument("-s", "--source", required=True, help="The source git tree.")
+parser.add_argument("-t", "--target", required=True, help="The target git tree.")
+parser.add_argument(
+    "-i", "--in-place",
+    required=False,
+    action="store_true",
+    help="Use this flag if you want to detect the differences in-place. Per default, the script clones the repo."
+)
+args = vars(parser.parse_args())
+
+source = args["source"]
+target = args["target"]
+modified_files = get_modified_files(source, target) if args["in_place"] else try_in(
+    prepare_repo(), lambda s=source, t=target: get_modified_files(s, t)
+)
+print("\n".join(modified_files))

--- a/bin/print_test_commands.py
+++ b/bin/print_test_commands.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2024 Dennis Gläser <dennis.a.glaeser@gmail.com>
+# SPDX-License-Identifier: MIT
+
+"""
+Prints the commands that can be used to compile or test the tests listed in a file,
+e.g. previously determined by the "detect_affected_tests.py" script.
+"""
+
+import sys
+import argparse
+
+
+def make_regex(tests: list[str]) -> str:
+    return "|".join(f"^{t}$" for t in tests)
+
+
+def print_command(cmd: str) -> None:
+    print(cmd, end="")
+
+
+parser = argparse.ArgumentParser(
+    description="Prints the command for building/testing the list of tests specified in the provided file. "
+                "If the file solely contains 'all', a command for running all tests is printed."
+)
+parser.add_argument(
+    "-b", "--build",
+    required=False,
+    action='store_true',
+    help="Use this flag to print the build command"
+)
+parser.add_argument(
+    "-t", "--test",
+    required=False,
+    action='store_true',
+    help="Use this flag to print the test command"
+)
+parser.add_argument(
+    "-a", "--ctest-args",
+    required=False,
+    default="",
+    help="String containing other arguments to be forwarded to ctest"
+)
+parser.add_argument(
+    "-f", "--tests-file",
+    required=True,
+    help="Name of the file with the list of tests to be run"
+)
+args = vars(parser.parse_args())
+do_build = args["build"]
+do_test = args["test"]
+if not do_build and not do_test:
+    sys.stderr.write("Either the 'build' or 'test' flag must be specified")
+    sys.exit(1)
+if do_build and do_test:
+    sys.stderr.write("One of the 'build' or 'test' flags must be specified")
+    sys.exit(1)
+
+tests = [n for n in open(args["tests_file"]).read().strip(" \n").split("\n") if n]
+ctest_args = args["ctest_args"]
+if tests == ["all"]:
+    print_command(f"ctest {ctest_args}") if do_test else print_command(f"make build_tests")
+elif tests == []:
+    print_command(f"echo 'Nothing to test...'") if do_test else print_command(f"echo 'Nothing to build...'")
+else:
+    print_command(f"ctest {ctest_args} -R {make_regex(tests)}") if do_test else print_command(f"make {' '.join(tests)}")


### PR DESCRIPTION
Add a test selection mechanism to the actions. On PRs, only the tests affected by files that have changes w.r.t main are selected, built and executed. On main, the full pipeline is run.

The examples & CLI tests still always run. We may run those only when changes in `examples` or `bin` are detected, but they are also affected by changes to the source files so it may be good to test them in this situation as well. Thus, the only real overhead is when no tests would be executed (e.g. when only changing the `README`). However, this should not be the main use case. An "empty-test-suite-pipeline" on the full setup (running all examples) takes approx. 15 at the moment...

- Tests that include headers that changed are executed (tested with a fake change on a previous version of this branch)
- If a `CMakeLists.txt` file is modified, all tests are run (tested with a fake change on a previous version of this branch)