### PR TITLE
[actions][test_cmds] fix if clause end

### DIFF
--- a/.github/actions/set-test-commands/action.yml
+++ b/.github/actions/set-test-commands/action.yml
@@ -25,17 +25,17 @@ runs:
             echo "Detecting tests affected by these changes"
             python3 ../bin/detect_affected_tests.py -i _modfiles.out -o ../_affected_tests.txt
           popd
-
-          BUILD_CMD=$(python3 bin/print_test_commands.py --build -f _affected_tests.txt)
-          echo "Setting build command to ${BUILD_CMD}"
-          echo "GFMT_BUILD_CMD=$BUILD_CMD" >> "$GITHUB_ENV"
-
-          TEST_CMD=$(python3 bin/print_test_commands.py --test -f _affected_tests.txt --ctest-args='--output-on-failure')
-          echo "Setting test command to ${TEST_CMD}"
-          echo "GFMT_TEST_CMD=$TEST_CMD" >> "$GITHUB_ENV"
-
-          MEMCHECK_CMD=$(python3 bin/print_test_commands.py --build -f _affected_tests.txt --memcheck)
-          echo "Setting memcheck command to ${MEMCHECK_CMD}"
-          echo "GFMT_MEMCHECK_CMD=$MEMCHECK_CMD" >> "$GITHUB_ENV"
         fi
+
+        BUILD_CMD=$(python3 bin/print_test_commands.py --build -f _affected_tests.txt)
+        echo "Setting build command to ${BUILD_CMD}"
+        echo "GFMT_BUILD_CMD=$BUILD_CMD" >> "$GITHUB_ENV"
+
+        TEST_CMD=$(python3 bin/print_test_commands.py --test -f _affected_tests.txt --ctest-args='--output-on-failure')
+        echo "Setting test command to ${TEST_CMD}"
+        echo "GFMT_TEST_CMD=$TEST_CMD" >> "$GITHUB_ENV"
+
+        MEMCHECK_CMD=$(python3 bin/print_test_commands.py --build -f _affected_tests.txt --memcheck)
+        echo "Setting memcheck command to ${MEMCHECK_CMD}"
+        echo "GFMT_MEMCHECK_CMD=$MEMCHECK_CMD" >> "$GITHUB_ENV"
       shell: bash


### PR DESCRIPTION
On main, the `all` target was not handled properly. Empty test commands led to the whole test suite being skipped.