### PR TITLE
[reuse] put licenses for .svg in separate files

### DIFF
--- a/docs/img/grid_image.svg.license
+++ b/docs/img/grid_image.svg.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2022-2023 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>
+SPDX-License-Identifier: CC-BY-4.0

--- a/docs/img/grid_rectilinear.svg.license
+++ b/docs/img/grid_rectilinear.svg.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2022-2023 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>
+SPDX-License-Identifier: CC-BY-4.0

--- a/docs/img/grid_structured.svg.license
+++ b/docs/img/grid_structured.svg.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2022-2023 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>
+SPDX-License-Identifier: CC-BY-4.0

--- a/docs/img/grid_unstructured.svg.license
+++ b/docs/img/grid_unstructured.svg.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2022-2023 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>
+SPDX-License-Identifier: CC-BY-4.0


### PR DESCRIPTION
With version 3.0 of the `reuse` tool, it doesn't like the licensing statement in the .svg headers anymore...