### PR TITLE
[workflows] reuse lint with action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,12 +43,12 @@ jobs:
 
     steps:
       - name: checkout-repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: check-reuse-compliance
-        run: python3 -m pip install reuse && reuse lint
+        uses: fsfe/reuse-action@v2
 
       - name: Check CITATION.cff validity
         uses: citation-file-format/cffconvert-github-action@2.0.0


### PR DESCRIPTION
`reuse lint` failed because it complained about the headers in the submodules (`HighFive`) not being compliant, see e.g. [here](https://github.com/dglaeser/gridformat/actions/runs/7604258438/job/20706938465).

Per default, submodules are skipped with `reuse lint`, so I am not entirely sure why this happens. Maybe it is because of the way the `checkout` actions pulls things?

In any case, using the reuse action it seems to work. Their docs use a newer version of checkout, and with this combo it works (but I didn't check `v2` of the checkout action, which we were using so far).