### PR TITLE
[ci] go back to gcc-12 / clang-16 / ubuntu-22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,8 @@ on:
   workflow_call:
 
 env:
-  DEFAULT_C_COMPILER: gcc-14
-  DEFAULT_CXX_COMPILER: g++-14
+  DEFAULT_C_COMPILER: gcc-12
+  DEFAULT_CXX_COMPILER: g++-12
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
 
@@ -32,16 +32,16 @@ jobs:
     container: dglaeser/gridformat-action-images:full
     strategy:
       matrix:
-        compiler_pkg: [g++-14, clang-18]
+        compiler_pkg: [g++-12, clang-16]
         include:
-           - c_compiler: gcc-14
-             compiler_pkg: g++-14
-           - cxx_compiler: g++-14
-             compiler_pkg: g++-14
-           - c_compiler: clang-18
-             compiler_pkg: clang-18
-           - cxx_compiler: clang++-18
-             compiler_pkg: clang-18
+           - c_compiler: gcc-12
+             compiler_pkg: g++-12
+           - cxx_compiler: g++-12
+             compiler_pkg: g++-12
+           - c_compiler: clang-16
+             compiler_pkg: clang-16
+           - cxx_compiler: clang++-16
+             compiler_pkg: clang-16
 
     steps:
       - name: checkout-repository

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # Dockerfile for the GridFormat GitHub actions
-FROM ubuntu:24.04 AS base
+FROM ubuntu:22.04 AS base
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get upgrade -y -o Dpkg::Options::="--force-confold" \
@@ -14,19 +14,20 @@ RUN apt-get update \
     && apt-get install --no-install-recommends --yes \
         build-essential \
         cmake \
-        g++-12 g++-14 \
-        clang-16 clang-18 \
+        g++-12 \
         python3 \
         python3-pip \
         python3-dev \
         python3-venv \
         wget \
-        software-properties-common \
         git \
         apt-utils \
         # for pages job
         rsync \
+        # for deal.ii
+        software-properties-common \
     && python3 -m venv /gfmt-venv && . /gfmt-venv/bin/activate && pip install vtk \
+    && wget https://apt.llvm.org/llvm.sh && /bin/bash llvm.sh 16 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/examples/mfem_traits/mfem_traits.cpp
+++ b/examples/mfem_traits/mfem_traits.cpp
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Timo Koch <timokoch@uio.no>
 // SPDX-License-Identifier: MIT
 
-#include <cstdint>  // to avoid missing type error in mfem with gcc 14
 #include "mfem.hpp"
 
 #include <gridformat/gridformat.hpp>

--- a/test/adapters/test_dune_unstructured.cpp
+++ b/test/adapters/test_dune_unstructured.cpp
@@ -16,7 +16,6 @@
 #pragma GCC diagnostic ignored "-Wuseless-cast"
 #pragma GCC diagnostic ignored "-Wuse-after-free"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wdangling-reference"
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"

--- a/test/vtk/test_vtk_hdf_parallel_unstructured_grid_reader.cpp
+++ b/test/vtk/test_vtk_hdf_parallel_unstructured_grid_reader.cpp
@@ -6,13 +6,9 @@
 
 #include <mpi.h>
 
-// On the github runner we run into a warning here (which wasn't possible to reproduce locally)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnull-dereference"
 #include <gridformat/vtk/hdf_unstructured_grid_writer.hpp>
 #include <gridformat/vtk/hdf_unstructured_grid_reader.hpp>
 #include <gridformat/vtk/hdf_reader.hpp>
-#pragma GCC diagnostic pop
 
 #include "../grid/unstructured_grid.hpp"
 #include "../make_test_data.hpp"

--- a/test/vtk/test_vtk_hdf_unstructured_grid_reader.cpp
+++ b/test/vtk/test_vtk_hdf_unstructured_grid_reader.cpp
@@ -1,13 +1,9 @@
 // SPDX-FileCopyrightText: 2022-2023 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>
 // SPDX-License-Identifier: MIT
 
-// On the github runner we run into a warning here (which wasn't possible to reproduce locally)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnull-dereference"
 #include <gridformat/vtk/hdf_unstructured_grid_writer.hpp>
 #include <gridformat/vtk/hdf_unstructured_grid_reader.hpp>
 #include <gridformat/vtk/hdf_reader.hpp>
-#pragma GCC diagnostic pop
 
 #include "../grid/unstructured_grid.hpp"
 #include "../make_test_data.hpp"


### PR DESCRIPTION
Upgrading to ubuntu-22.04 and newer compiler versions requires quite some more work, as compilation of the dependencies breaks, deal.ii is only available in a newer version, etc...

This PR reverts the changes made recently to make the pipeline pass again. In a follow-up PR we will try to introduce all changes required for compatibility with newer os/compiler versions.