### PR TITLE
[CI] reduce runtime

### DIFF
--- a/.github/actions/set-test-commands/action.yml
+++ b/.github/actions/set-test-commands/action.yml
@@ -22,6 +22,7 @@ runs:
             ( ${{ github.ref_type }} == "tag" && ${{ github.ref_name }} =~ v[0-9]\.[0-9]\.[0-9]$ )]]; then
           echo "Using 'all' target on main branch (i.e. all tests are built & run)"
           echo "all" > _affected_tests.txt
+          echo "GFMT_TEST_EXAMPLES=true" >> "$GITHUB_ENV"
         else
           echo "Regression-testing sample files only for branch ${{ github.ref_name }}"
           echo "GRIDFORMAT_REGRESSION_SAMPLES_ONLY=true" >> "$GITHUB_ENV"
@@ -34,6 +35,11 @@ runs:
               -tr "${{inputs.target_remote}}" \
               -t "${{inputs.target_tree}}" \
               -o _modfiles.out
+
+            if cat _modfiles.out | grep 'examples/'; then
+              echo "Including examples in tests"
+              echo "GFMT_TEST_EXAMPLES=true" >> "$GITHUB_ENV"
+            fi
 
             echo "Detecting tests affected by these changes"
             python3 ../test/detect_affected_tests.py -i _modfiles.out -o ../_affected_tests.txt

--- a/.github/actions/test-installed-pkg/action.yml
+++ b/.github/actions/test-installed-pkg/action.yml
@@ -87,6 +87,7 @@ runs:
       shell: bash
 
     - name: test-examples
+      if: ${{ env.GFMT_TEST_EXAMPLES }}
       run: |
         pushd examples
           cmake -DCMAKE_C_COMPILER=${{inputs.c_compiler}} \
@@ -98,6 +99,7 @@ runs:
       shell: bash
 
     - name: test-examples-with-fetch-content
+      if: ${{ env.GFMT_TEST_EXAMPLES }}
       run: |
         rm -rf examples/build && pushd examples
           cmake -DCMAKE_C_COMPILER=${{inputs.c_compiler}} \

--- a/.github/actions/test-installed-pkg/action.yml
+++ b/.github/actions/test-installed-pkg/action.yml
@@ -7,6 +7,8 @@ inputs:
     required: true
   cxx_compiler:
     required: true
+  allow_skipped_tests:
+    required: true
 runs:
   using: composite
   steps:
@@ -21,6 +23,7 @@ runs:
       run: |
         cmake -DCMAKE_C_COMPILER=${{inputs.c_compiler}} \
               -DCMAKE_CXX_COMPILER=${{inputs.cxx_compiler}} \
+              -DCMAKE_BUILD_TYPE=Release \
               -DGRIDFORMAT_BUILD_TESTS=ON \
               -DGRIDFORMAT_BUILD_BINARIES=ON \
               -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
@@ -70,6 +73,17 @@ runs:
             echo "Invoking test command"
             $(echo "$GFMT_TEST_CMD")
           popd
+      shell: bash
+
+    - name: verify-no-skipped-tests
+      if: ${{ ! inputs.allow_skipped_tests }}
+      run: |
+        if [[ -e installation-test/build/Testing/Temporary/LastTestsDisabled.log ]]; then
+          echo "The full test suite should not skip any tests. Making the job fail..."
+          exit 1
+        else
+          echo "No skipped tests detected"
+        fi
       shell: bash
 
     - name: test-examples

--- a/.github/actions/test-installed-pkg/action.yml
+++ b/.github/actions/test-installed-pkg/action.yml
@@ -76,38 +76,47 @@ runs:
       shell: bash
 
     - name: verify-no-skipped-tests
-      if: ${{ ! inputs.allow_skipped_tests }}
       run: |
-        if [[ -e installation-test/build/Testing/Temporary/LastTestsDisabled.log ]]; then
-          echo "The full test suite should not skip any tests. Making the job fail..."
-          exit 1
+        if [[ '${{ inputs.allow_skipped_tests }}' != 'true' ]]; then
+          if [[ -e installation-test/build/Testing/Temporary/LastTestsDisabled.log ]]; then
+            echo "The full test suite should not skip any tests. Making the job fail..."
+            exit 1
+          else
+            echo "No skipped tests detected"
+          fi
         else
-          echo "No skipped tests detected"
+            echo "Skipping verification that no tests have been skipped"
         fi
       shell: bash
 
     - name: test-examples
-      if: ${{ env.GFMT_TEST_EXAMPLES }}
       run: |
-        pushd examples
-          cmake -DCMAKE_C_COMPILER=${{inputs.c_compiler}} \
-                -DCMAKE_CXX_COMPILER=${{inputs.cxx_compiler}} \
-                -DCMAKE_PREFIX_PATH=/gfmt-dependencies \
-                -Dgridformat_ROOT=$(pwd)/../install \
-                -B build
-        pushd build && make && ctest --output-on-failure
+        if [[ '${{ env.GFMT_TEST_EXAMPLES }}' == 'true' ]]; then
+          pushd examples
+            cmake -DCMAKE_C_COMPILER=${{inputs.c_compiler}} \
+                  -DCMAKE_CXX_COMPILER=${{inputs.cxx_compiler}} \
+                  -DCMAKE_PREFIX_PATH=/gfmt-dependencies \
+                  -Dgridformat_ROOT=$(pwd)/../install \
+                  -B build
+          pushd build && make && ctest --output-on-failure
+        else
+          echo "Skipping example testing"
+        fi
       shell: bash
 
     - name: test-examples-with-fetch-content
-      if: ${{ env.GFMT_TEST_EXAMPLES }}
       run: |
-        rm -rf examples/build && pushd examples
-          cmake -DCMAKE_C_COMPILER=${{inputs.c_compiler}} \
-                -DCMAKE_CXX_COMPILER=${{inputs.cxx_compiler}} \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_PREFIX_PATH=/gfmt-dependencies \
-                -DGRIDFORMAT_FETCH_TREE="$GFMT_SOURCE_TREE" \
-                -DGRIDFORMAT_ORIGIN="$GFMT_SOURCE_REMOTE" \
-                -B build
-        pushd build && make && ctest --output-on-failure
+        if [[ '${{ env.GFMT_TEST_EXAMPLES }}' == 'true' ]]; then
+          rm -rf examples/build && pushd examples
+            cmake -DCMAKE_C_COMPILER=${{inputs.c_compiler}} \
+                  -DCMAKE_CXX_COMPILER=${{inputs.cxx_compiler}} \
+                  -DCMAKE_BUILD_TYPE=Release \
+                  -DCMAKE_PREFIX_PATH=/gfmt-dependencies \
+                  -DGRIDFORMAT_FETCH_TREE="$GFMT_SOURCE_TREE" \
+                  -DGRIDFORMAT_ORIGIN="$GFMT_SOURCE_REMOTE" \
+                  -B build
+          pushd build && make && ctest --output-on-failure
+        else
+          echo "Skipping example testing"
+        fi
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,22 +28,9 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
 
 jobs:
-  test-compilers:
+  sanity-checks:
     runs-on: ubuntu-22.04
     container: dglaeser/gridformat-action-images:full
-    strategy:
-      matrix:
-        compiler_pkg: [g++-12, clang-16]
-        include:
-           - c_compiler: gcc-12
-             compiler_pkg: g++-12
-           - cxx_compiler: g++-12
-             compiler_pkg: g++-12
-           - c_compiler: clang-16
-             compiler_pkg: clang-16
-           - cxx_compiler: clang++-16
-             compiler_pkg: clang-16
-
     steps:
       - name: checkout-repository
         uses: actions/checkout@v4
@@ -64,8 +51,8 @@ jobs:
       - name: configure
         run: |
           rm -rf build
-          cmake -DCMAKE_C_COMPILER=${{matrix.c_compiler}} \
-                -DCMAKE_CXX_COMPILER=${{matrix.cxx_compiler}} \
+          cmake -DCMAKE_C_COMPILER=$DEFAULT_C_COMPILER \
+                -DCMAKE_CXX_COMPILER=$DEFAULT_CXX_COMPILER \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_PREFIX_PATH=/gfmt-dependencies \
                 -DGRIDFORMAT_BUILD_BINARIES=ON \
@@ -74,15 +61,6 @@ jobs:
 
       - name: set-git-variables
         uses: ./.github/actions/set-git-variables
-
-      - name: set-test-commands
-        uses: ./.github/actions/set-test-commands
-        with:
-          build_directory: build
-          source_remote: ${{ env.GFMT_SOURCE_REMOTE }}
-          source_tree: ${{ env.GFMT_SOURCE_TREE }}
-          target_remote: ${{ env.GFMT_TARGET_REMOTE }}
-          target_tree: ${{ env.GFMT_TARGET_TREE }}
 
       - name: check-documentation-code
         run: |
@@ -93,30 +71,9 @@ jobs:
           python3 test/test_readme_tested_versions.py --cmake-log-file gfmt_cmake_log.txt
         shell: bash
 
-      - name: build-binaries
-        run: cmake --build build
-
-      - name: build-tests
-        run: pushd build && $(echo "$GFMT_BUILD_CMD") && popd
-        shell: bash
-
-      - name: test
-        run: |
-          pushd build && $(echo "$GFMT_TEST_CMD") && popd
-        shell: bash
-
-      - name: verify-no-skipped-tests
-        run: |
-          if [[ -e build/Testing/Temporary/LastTestsDisabled.log ]]; then
-            echo "The full test suite should not skip any tests. Making the job fail..."
-            exit 1
-          else
-            echo "No skipped tests detected"
-          fi
-        shell: bash
-
 
   mem-check:
+    needs: sanity-checks
     runs-on: ubuntu-22.04
     container: dglaeser/gridformat-action-images:full
     steps:
@@ -155,8 +112,21 @@ jobs:
 
 
   test-full-installation:
+    needs: sanity-checks
     runs-on: ubuntu-22.04
     container: dglaeser/gridformat-action-images:full
+    strategy:
+      matrix:
+        compiler_pkg: [g++-12, clang-16]
+        include:
+          - c_compiler: gcc-12
+            compiler_pkg: g++-12
+          - cxx_compiler: g++-12
+            compiler_pkg: g++-12
+          - c_compiler: clang-16
+            compiler_pkg: clang-16
+          - cxx_compiler: clang++-16
+            compiler_pkg: clang-16
     steps:
       - name: checkout-repository
         uses: actions/checkout@v2
@@ -166,11 +136,13 @@ jobs:
       - name: test-installed-package
         uses: ./.github/actions/test-installed-pkg
         with:
-          c_compiler: /usr/bin/$DEFAULT_C_COMPILER
-          cxx_compiler: /usr/bin/$DEFAULT_CXX_COMPILER
+          c_compiler: /usr/bin/${{ matrix.c_compiler }}
+          cxx_compiler: /usr/bin/${{ matrix.cxx_compiler }}
+          allow_skipped_tests: false
 
 
   test-minimal-installation:
+    needs: sanity-checks
     runs-on: ubuntu-22.04
     container: dglaeser/gridformat-action-images:minimal
     steps:
@@ -184,3 +156,4 @@ jobs:
         with:
           c_compiler: /usr/bin/$DEFAULT_C_COMPILER
           cxx_compiler: /usr/bin/$DEFAULT_CXX_COMPILER
+          allow_skipped_tests: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - on PRs, a bunch of performance benchmarks are run with the code of the PR and the target branch, and observed runtime differences are posted as a comment to the pull request.
 - the CI helper scripts, for instance, to select tests affected by changes, have been moved from the `/bin` to the  `/test` directory.
+- the runtime of the test pipeline has been reduced by avoiding duplicate test runs and skipping those tests in pull requests for which no changes are introduced.
 
 # `GridFormat` 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,19 @@
 ## Features
 
 - __Traits__: support for writing `Dune::FieldMatrix` as tensor field data.
-- __CI__: on PRs, a bunch of performance benchmarks are run with the code of the PR and the target branch, and observed runtime differences are posted as a comment to the pull request.
 - __Reader__: the `Reader` class now allows for opening a file upon instantiation using `GridFormat::Reader::from(filename)` (taking further optional constructor arguments). Moreover, you can now open a file and receive the modified reader as return value using `reader.with_opened(filename)`.
 - __VTK__: VTK-XML files of the older file format version 0.1 can now also be read by all vtk readers
 
 ## Deprecated interfaces
 
-- __CI__: the CI helper scripts, for instance, to select tests affected by changes, have been moved from the `/bin` to the  `/test` directory.
 - __Common__:
     - the `get_md_layout<SubRange>(std::size_t)` overload is deprecated as it may interfere with `get_md_layout<Range>(Range)` if `Range` is constructible from an `std::size_t` and the template argument `Range` is explicitly specified. The intented behaviour can now be achieved with `MDLayout{{std::size_t}}.with_sub_layout_from<SubRange>()`.
     - related to the above, an `MDLayout` for a scalar value now has a dimension of zero to distinguish it from a vector of size 1.
+
+## Continuous integration
+
+- on PRs, a bunch of performance benchmarks are run with the code of the PR and the target branch, and observed runtime differences are posted as a comment to the pull request.
+- the CI helper scripts, for instance, to select tests affected by changes, have been moved from the `/bin` to the  `/test` directory.
 
 # `GridFormat` 0.2.0
 


### PR DESCRIPTION
This PR:

- turns the `test-full-installation` into a matrix job
- removes the matrix strategy from the main test suite 
- reduces the main test suite to a simple sanity check job since the full installation test runs all tests.
- runs the examples only when changes to the example folder have been made, or the 'all' target was selected