### PR TITLE
Feature/improve release procedure documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 <!--SPDX-FileCopyrightText: 2023 Dennis Gläser <dennis.glaeser@iws.uni-stuttgart.de>-->
 <!--SPDX-License-Identifier: MIT-->
 
-# `GridFormat` 0.2.1
+# `GridFormat` 0.3.0
 
 ## Features
 
+- __Writers__: the custom range adaptors & iterators used by the writers under the hood have been changed to support range sentinels of different type than the range iterator. This makes it easier to specialize the traits for grid implementations that use sentinels of different type than the grid entity iterators.
+- __CI__: the CI now runs on ubuntu:24.04 and tests the code with `gcc-14` and `clang-18`.
 - __Traits__: support for writing `Dune::FieldMatrix` as tensor field data.
 - __Reader__: the `Reader` class now allows for opening a file upon instantiation using `GridFormat::Reader::from(filename)` (taking further optional constructor arguments). Moreover, you can now open a file and receive the modified reader as return value using `reader.with_opened(filename)`.
 - __VTK__: VTK-XML files of the older file format version 0.1 can now also be read by all vtk readers

--- a/README.md
+++ b/README.md
@@ -224,11 +224,13 @@ If your Python environment does not have `VTK`, this step is skipped. Note that 
 
 To create a release, you may use the utility script `util/update_versions.py`, which creates a git tag and adjusts the versions and
 release dates specified in the cmake setup and the `CITATION.cff` file. For each minor release, we maintain a separate branch for bugfixes
-and patch releases. As an example, to create a new minor release version `1.2`, you may type the following into the console (assumes a clean
-repository):
+and patch releases. As an example, to create a new minor release version `1.2`, you may type type the following into the console:
 
 ```bash
+git switch main  # a new minor release should always be started from main
+git pull --rebase origin main  # make sure the local state matches the remote state
 git switch --create releases/1.2  # this branch will be kept for incorporation of bug fixes and patch release tags 1.2.X
+# ... from now on, only changes that are important for v1.2 but should NOT go into main should be committed on this branch
 python3 util/update_versions.py -v 1.2.0 # modifies versions&dates and creates a commit + tag
 git push origin releases/1.2
 git push origin v1.2.0

--- a/README.md
+++ b/README.md
@@ -223,8 +223,7 @@ If your Python environment does not have `VTK`, this step is skipped. Note that 
 ### Creating a release
 
 To create a release, you may use the utility script `util/update_versions.py`, which creates a git tag and adjusts the versions and
-release dates specified in the cmake setup and the `CITATION.cff` file. For each minor release, we maintain a separate branch for bugfixes
-and patch releases. As an example, to create a new minor release version `1.2`, you may type type the following into the console:
+release dates specified in the cmake setup and the `CITATION.cff` file. We maintain a branch for each minor release to incorporate bug fixes and patch releases. As an example, to create a new minor release version `1.2`, you may type type the following into the console:
 
 ```bash
 git switch main  # a new minor release should always be started from main

--- a/README.md
+++ b/README.md
@@ -223,16 +223,15 @@ If your Python environment does not have `VTK`, this step is skipped. Note that 
 ### Creating a release
 
 To create a release, you may use the utility script `util/update_versions.py`, which creates a git tag and adjusts the versions and
-release dates specified in the cmake setup and the `CITATION.cff` file. For each release we maintain a separate branch for bugfixes
-and patch releases. As an example, to create a release version `1.2.3`, you may type the following into the console (assumes a clean
+release dates specified in the cmake setup and the `CITATION.cff` file. For each minor release, we maintain a separate branch for bugfixes
+and patch releases. As an example, to create a new minor release version `1.2`, you may type the following into the console (assumes a clean
 repository):
 
 ```bash
-git switch --create releases/1.2.3
-# ... maybe continue development ...
-python3 util/update_versions.py -v 1.2.3 # modifies versions&dates and creates a commit + tag
-git push origin releases/1.2.3
-git push origin v1.2.3
+git switch --create releases/1.2  # this branch will be kept for incorporation of bug fixes and patch release tags 1.2.X
+python3 util/update_versions.py -v 1.2.0 # modifies versions&dates and creates a commit + tag
+git push origin releases/1.2
+git push origin v1.2.0
 ```
 
 Afterwards, a release workflow will be triggered. If this runs through successfully, a release has been created. If not, the new tag
@@ -242,8 +241,9 @@ should be increased (without triggering an actual release). Following the above 
 ```bash
 git switch main
 git switch --create feature/bump-version
-python3 util/update_versions.py -v 1.2.4 --skip-tag # only modifies versions, no commit or tag
-git commit -m "bump version to v1.2.4" .
+# .. add a new section for release 1.3 in the CHANGELOG and commit it
+python3 util/update_versions.py -v 1.3 --skip-tag # only modifies versions, no commit or tag
+git commit -m "bump version to v1.3" .
 git push origin feature/bump-version
 ```
 


### PR DESCRIPTION
The release approach so far, and its documentation, had a couple of flaws in my opinion:

> ```bash
> git switch --create releases/1.2.3
> # ... maybe continue development ...
> python3 util/update_versions.py -v 1.2.3 # modifies versions&dates and creates a commit + tag
> git push origin releases/1.2.3
> git push origin v1.2.3
> ```

I think this makes little sense. One should not develop on a patch release branch and push changes there. All developments should happen on feature branches and should be merged into main. This documentation has been changed to describing how to create a new minor release, which should be the most common situation -> whenever there are new features, a new minor release should be made. Patch releases may solely contain bugfixes wrt an earlier minor release. Thus, from now on we keep a branch for each minor release, and cherry-pick bug fixes into them if necessay. A patch release can then be created as stated in the updated documentation, with the difference that the minor release branch does not have to be created. 