### PR TITLE
Feature: [vtk][reader] Support polylines

### DIFF
--- a/gridformat/grid/cell_type.hpp
+++ b/gridformat/grid/cell_type.hpp
@@ -23,6 +23,7 @@ enum class CellType {
     triangle,
     pixel,
     quadrilateral,
+    polyline,
     polygon,
 
     tetrahedron,

--- a/gridformat/traits/dune.hpp
+++ b/gridformat/traits/dune.hpp
@@ -1023,6 +1023,7 @@ inline constexpr ::Dune::GeometryType to_dune_geometry_type(const CellType& ct) 
         case CellType::tetrahedron: return DGT::tetrahedron;
         case CellType::hexahedron: return DGT::hexahedron;
         case CellType::voxel: return DGT::hexahedron;
+        case CellType::polyline: throw NotImplemented("No conversion from polyline to Dune::GeometryType");
         case CellType::polygon: throw NotImplemented("No conversion from polygon to Dune::GeometryType");
         case CellType::lagrange_segment: throw NotImplemented("Cannot map higher-order cells to Dune::GeometryType");
         case CellType::lagrange_triangle: throw NotImplemented("Cannot map higher-order cells to Dune::GeometryType");

--- a/gridformat/vtk/common.hpp
+++ b/gridformat/vtk/common.hpp
@@ -78,6 +78,7 @@ inline constexpr std::uint8_t cell_type_number(CellType t) {
     switch (t) {
         case (CellType::vertex): return 1;
         case (CellType::segment): return 3;
+        case (CellType::polyline): return 4;
         case (CellType::triangle): return 5;
         case (CellType::pixel): return 8;
         case (CellType::quadrilateral): return 9;
@@ -99,6 +100,7 @@ inline constexpr CellType cell_type(std::uint8_t vtk_id) {
     switch (vtk_id) {
         case 1: return CellType::vertex;
         case 3: return CellType::segment;
+        case 4: return CellType::polyline;
         case 5: return CellType::triangle;
         case 8: return CellType::pixel;
         case 9: return CellType::quadrilateral;

--- a/gridformat/vtk/vtp_reader.hpp
+++ b/gridformat/vtk/vtp_reader.hpp
@@ -82,7 +82,7 @@ class VTPReader : public GridReader {
         if (_num_verts > 0)
             _visit_cells("Verts", CellType::vertex, _num_verts, visitor);
         if (_num_lines > 0)
-            _visit_cells("Lines", CellType::segment, _num_lines, visitor);
+            _visit_cells("Lines", CellType::polyline, _num_lines, visitor);
         if (_num_polys > 0)
             _visit_cells("Polys", CellType::polygon, _num_polys, visitor);
     }
@@ -122,10 +122,14 @@ class VTPReader : public GridReader {
                 throw ValueError("Invalid offset array");
             std::copy_n(connectivity.begin() + offset_begin, offset_end - offset_begin, std::back_inserter(corners));
 
+            // look for cell types that allow for a more specific classification
             const CellType ct = cell_type == CellType::polygon ? (
                     corners.size() == 3 ? CellType::triangle
                                         : (corners.size() == 4 ? CellType::quadrilateral : cell_type)
-                ) : cell_type;
+                ) : (cell_type == CellType::polyline ? (
+                    corners.size() == 2 ? CellType::segment
+                                        : cell_type
+                ) : cell_type);
             visitor(ct, corners);
         }
     }


### PR DESCRIPTION
Add basic support for VTK polylines in the reader. Polylines with two corners are converted to a segment, so there should be no change in behavior. This does not propose yet to actually handle polylines in any of the implemented adapters. The change in the Dune traits deals with an error from the CI test suite because not all enum states are handled in a switch statement (I guess that's because of the pedantic settings in the CI?).

Based on this PR I was able to [write a custom reader](https://git.iws.uni-stuttgart.de/dumux-repositories/dumux/-/merge_requests/3934/diffs?commit_id=81458615c6a4bbe0fb535f3b53e06b9704a290d3) that handles polylines and data by splitting polylines into segments.