### PR TITLE
Feature/more lenient ascii xml parsing for floats

### DIFF
--- a/gridformat/vtk/xml.hpp
+++ b/gridformat/vtk/xml.hpp
@@ -535,8 +535,11 @@ namespace XMLDetail {
                 buffer.begin()
             );
             const auto number_of_values_read = std::ranges::distance(buffer.begin(), out);
-            if (number_of_values_read < 0 || static_cast<std::size_t>(number_of_values_read) < expected_num_values)
+            if (number_of_values_read < 0 || static_cast<std::size_t>(number_of_values_read) < expected_num_values) {
+                if (_stream.fail())
+                    throw IOError("A read value could not be converted to type: " + typeid(TargetType).name());
                 throw SizeError("Could not read the requested number of values from the stream");
+            }
         }
 
         template<typename Decoder>


### PR DESCRIPTION
The current XML ASCII parser is not able to parse `Float32` data arrays that contain values like `5.70328e-43` (the minimum representable value is `1.17549e-38` for `float` (`std::numeric_limits<float>::min()`).
The thrown exception, in this case, is a `SizeError("Could not read the requested number of values from the stream")` because the input stream iterator stops as soon as it encounters a value that it cannot convert to `float`. 

The exception is not very informative. As `std::failbit` is set in this case (see https://en.cppreference.com/w/cpp/io/basic_istream/operator_gtgt) it can be improved.

Moreover, I want to bring up the suggestion to be more lenient and parse as `double` (because so far the largest type is `Float64`) and then convert types explicitly (implicit conversion actually also works). Needs to be determined if this impacts performance.

Also, I saw that something similar is done for small integer types. But not sure if this is exactly the same reason. @dglaeser why in this case it was better to copy into a buffer first and then copy the buffer? Did this give better performance?

Finally, it can be argued that such files are simply ill-formed. Actually, Paraview 3.12 gives a parser error (data array too short) on such files as well. Then, the writer that produced this file may need to be fixed. (It's a regression test file that is part of my program's test suite and I couldn't determine its origin but it's a simulation output). Hence I marked this as draft.
_Edit:_ it seems that this is fixed in the newest version of our writer and the file in the regression test seems quite old (back then it must have also worked with paraview). So I guess it's ok to drop the commit with special handling of floats.