### PR TITLE
Make FilteredRange movable and copy constructible

### DIFF
--- a/gridformat/common/filtered_range.hpp
+++ b/gridformat/common/filtered_range.hpp
@@ -118,6 +118,20 @@ class FilteredRange {
     , _pred{std::move(pred)}
     {}
 
+    FilteredRange(FilteredRange&&) noexcept = default;
+    FilteredRange& operator=(FilteredRange&&) noexcept = default;
+
+    FilteredRange(const FilteredRange& other){
+        _range = other._range;
+        _pred = other._pred;
+    }
+
+    FilteredRange& operator=(const FilteredRange& other) {
+        _range = other._range;
+        _pred = other._pred;
+        return *this;
+    }
+
     auto begin() const {
         return FilteredRangeDetail::Iterator{
             std::ranges::begin(_range),

--- a/test/common/test_filtered_range.cpp
+++ b/test/common/test_filtered_range.cpp
@@ -12,6 +12,18 @@ int main() {
     using GridFormat::Testing::operator""_test;
     using GridFormat::Testing::expect;
 
+    "filtered_range_is_viewable_range"_test = [] () {
+        static_assert(std::ranges::viewable_range<
+            GridFormat::FilteredRange<std::vector<int>, decltype([](int){ return true; })>
+        >);
+    };
+
+    "filtered_range_is_forward_range"_test = [] () {
+        static_assert(std::ranges::forward_range<
+            GridFormat::FilteredRange<std::vector<int>, decltype([](int){ return true; })>
+        >);
+    };
+
     "filtered_range_first_true"_test = [] () {
         std::vector<int> v{1, 2, 3, 4, 0, 1, 8, 1};
         const auto filtered = GridFormat::Ranges::filter_by([] (int value) { return value < 3; }, v);


### PR DESCRIPTION
Fix `FilteredRange` such that it can be used as an alternative for `std::views::filter` for `Cells`/`Vertex` traits. See #319.