### PR TITLE
Fix: 3d grid connectivity on test structured grids

### DIFF
--- a/test/grid/structured_grid.hpp
+++ b/test/grid/structured_grid.hpp
@@ -111,7 +111,7 @@ class StructuredGrid {
             const auto incremented = [] (auto pos, int dir) { pos[dir]++; return pos; };
             std::vector point_ids{cell_pos};
             point_ids.push_back(incremented(cell_pos, 0));
-            if constexpr (dim == 2) {
+            if constexpr (dim > 1) {
                 point_ids.push_back(incremented(incremented(cell_pos, 0), 1));
                 point_ids.push_back(incremented(cell_pos, 1));
             }


### PR DESCRIPTION
We broke the 3d test grids with #323, and it was not detected as on PRs we only regression test sample files (probably no 3d file was selected). 