### PR TITLE
Fix: avoid writer issues with ranges returning `__int128` from `Ranges::size`

### DIFF
--- a/gridformat/common/ranges.hpp
+++ b/gridformat/common/ranges.hpp
@@ -32,8 +32,8 @@ namespace GridFormat::Ranges {
  */
 template<std::ranges::sized_range R>
     requires(!Concepts::StaticallySizedRange<R>)
-inline constexpr auto size(R&& r) {
-    return std::ranges::size(r);
+inline constexpr std::size_t size(R&& r) {
+    return static_cast<std::size_t>(std::ranges::size(r));
 }
 
 /*!
@@ -44,8 +44,8 @@ inline constexpr auto size(R&& r) {
 template<std::ranges::range R>
     requires(!std::ranges::sized_range<R> and
              !Concepts::StaticallySizedRange<R>)
-inline constexpr auto size(R&& r) {
-    return std::ranges::distance(r);
+inline constexpr std::size_t size(R&& r) {
+    return static_cast<std::size_t>(std::ranges::distance(r));
 }
 
 /*!
@@ -53,8 +53,8 @@ inline constexpr auto size(R&& r) {
  * \brief Return the size of a range with size known at compile time.
  */
 template<Concepts::StaticallySizedRange R>
-inline constexpr auto size(R&&) {
-    return static_size<R>;
+inline constexpr std::size_t size(R&&) {
+    return static_cast<std::size_t>(static_size<R>);
 }
 
 /*!


### PR DESCRIPTION
In one application (using `CGAL` with the exact kernel) we ran into the case that for a given range, `Ranges::size` returned an `__int128` with `gcc`. In particular, `Ranges::size(grid_points)` returned an `__int128` when determining the number of points in the grid. This led to a compiler error because parsing to string for this data type didn't work, which is required to write the number of points into a vtk file.

This PR changes the result type of `Ranges::size` to `std:.size_t`. That is, in the mentioned case there is some precision loss. I'm not entirely sure why an `__int128` was returned in this case. The standard does not specify the return type of `std::ranges::size`, but I believe most `.size()` functions of the standard library return `std::size_t`. I guess it's fine to simply cast to an `std::size_t` in this case. On typical architectures, it would only break for an insane amount of points/cells in the grid, I suppose.